### PR TITLE
chore: ajusta cron Mobne para 1x/dia (Hobby plan)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
   "crons": [
     {
       "path": "/api/cron/mobneSync",
-      "schedule": "0 */8 * * *"
+      "schedule": "0 6 * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
Vercel Hobby só permite 1 execução por dia.
Schedule: '0 6 * * *' — todo dia às 06:00 UTC.

https://claude.ai/code/session_01WPAq8pEGje5qYcMZkDFMHu