### PR TITLE
fix: restaura bloco functions no vercel.json sem runtime inválido

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,11 @@
   "buildCommand": "cd frontend && npm install && npm run build",
   "outputDirectory": "frontend/dist",
   "installCommand": "cd backend && npm install",
+  "functions": {
+    "backend/api/**/*.js": {
+      "maxDuration": 30
+    }
+  },
   "rewrites": [
     { "source": "/api/auth/login", "destination": "/backend/api/auth/login" },
     { "source": "/api/auth/validate", "destination": "/backend/api/auth/validate" },


### PR DESCRIPTION
Sem o bloco functions o Vercel não reconhece os arquivos de backend/api/ como serverless functions, retornando 405. Mantém apenas maxDuration sem especificar runtime.

https://claude.ai/code/session_01WPAq8pEGje5qYcMZkDFMHu