### PR TITLE
fix: garante que setError sempre recebe string, não objeto {code,mess…

### DIFF
--- a/frontend/src/components/Auth/LoginForm.jsx
+++ b/frontend/src/components/Auth/LoginForm.jsx
@@ -16,7 +16,8 @@ export function LoginForm({ onSuccess }) {
       await login(email, password);
       onSuccess?.();
     } catch (err) {
-      setError(err.response?.data?.error || 'Erro ao fazer login. Tente novamente.');
+      const msg = err.response?.data?.error;
+      setError(typeof msg === 'string' ? msg : 'Erro ao fazer login. Tente novamente.');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/Upload/ExcelUploader.jsx
+++ b/frontend/src/components/Upload/ExcelUploader.jsx
@@ -40,7 +40,8 @@ export function ExcelUploader({ onUploadSuccess }) {
       setProgress(100);
       onUploadSuccess?.(data);
     } catch (err) {
-      setError(err.response?.data?.error || 'Erro ao fazer upload.');
+      const msg = err.response?.data?.error;
+      setError(typeof msg === 'string' ? msg : 'Erro ao fazer upload.');
     } finally {
       setUploading(false);
       setTimeout(() => setProgress(0), 1500);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,6 +11,9 @@ class ErrorBoundary extends React.Component {
   static getDerivedStateFromError(error) {
     return { error };
   }
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
   render() {
     if (this.state.error) {
       return (


### PR DESCRIPTION
…age}