### PR TITLE
feat: dashboard de faturamento diário via API Mobne PedidoVenda

### DIFF
--- a/api/reports/billing.js
+++ b/api/reports/billing.js
@@ -1,0 +1,127 @@
+import 'dotenv/config';
+import { requireAuth } from '../../middleware/auth.js';
+import { errorResponse, successResponse, corsHeaders } from '../../lib/utils.js';
+
+const MOBNE_BASE_URL = process.env.MOBNE_API_URL || 'https://apiexternal.mobne.com.br/api/v1';
+const MOBNE_API_KEY = process.env.MOBNE_API_KEY;
+const EMPRESA_ID = '218';
+
+function generateMockBilling(dataInicio, dataFim) {
+  const start = new Date(dataInicio);
+  const end = new Date(dataFim);
+  const items = [];
+  let id = 1;
+
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const pedidosDoDia = Math.floor(Math.random() * 15) + 3;
+    for (let i = 0; i < pedidosDoDia; i++) {
+      items.push({
+        Id: `mock-${id++}`,
+        dataEmissao: d.toISOString().slice(0, 10),
+        valorTotal: parseFloat((Math.random() * 800 + 50).toFixed(2)),
+        _mock: true,
+      });
+    }
+  }
+
+  return { Data: { Items: items, Paging: { TotalPages: 1, PageNumber: 1, TotalItems: items.length } } };
+}
+
+async function fetchPedidosVenda(dataInicio, dataFim) {
+  if (!MOBNE_API_KEY) {
+    return generateMockBilling(dataInicio, dataFim);
+  }
+
+  const allItems = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const params = new URLSearchParams({
+      PageSize: 500,
+      PageNumber: page,
+      DataInicio: dataInicio,
+      DataFim: dataFim,
+    });
+
+    const response = await fetch(`${MOBNE_BASE_URL}/PedidoVenda?${params}`, {
+      headers: {
+        Authorization: `ApiKey ${MOBNE_API_KEY}`,
+        empresaId: EMPRESA_ID,
+      },
+    });
+
+    if (!response.ok) throw new Error(`Mobne API error: ${response.status} ${response.statusText}`);
+
+    const json = await response.json();
+    const items = json?.Data?.Items || [];
+    totalPages = json?.Data?.Paging?.TotalPages ?? 1;
+
+    allItems.push(...items);
+    page++;
+  } while (page <= totalPages && page <= 20); // cap at 20 pages for safety
+
+  return { Data: { Items: allItems } };
+}
+
+function groupByDay(items) {
+  const map = {};
+
+  for (const item of items) {
+    const date = (item.dataEmissao || item.DataEmissao || '').slice(0, 10);
+    if (!date) continue;
+
+    if (!map[date]) map[date] = { total: 0, count: 0 };
+    map[date].total += parseFloat(item.valorTotal || item.ValorTotal || 0);
+    map[date].count += 1;
+  }
+
+  return Object.entries(map)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, { total, count }]) => ({
+      date,
+      total: parseFloat(total.toFixed(2)),
+      count,
+      ticketMedio: count > 0 ? parseFloat((total / count).toFixed(2)) : 0,
+    }));
+}
+
+export default async function handler(req, res) {
+  Object.entries(corsHeaders()).forEach(([k, v]) => res.setHeader(k, v));
+
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'GET') return errorResponse(res, 405, 'Método não permitido.');
+
+  const user = await requireAuth(req, res);
+  if (!user) return;
+
+  const hoje = new Date().toISOString().slice(0, 10);
+  const trintaDiasAtras = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const dataInicio = req.query.dataInicio || trintaDiasAtras;
+  const dataFim = req.query.dataFim || hoje;
+
+  try {
+    const { Data } = await fetchPedidosVenda(dataInicio, dataFim);
+    const items = Data?.Items || [];
+    const daily = groupByDay(items);
+
+    const totalFaturado = daily.reduce((sum, d) => sum + d.total, 0);
+    const totalPedidos = daily.reduce((sum, d) => sum + d.count, 0);
+    const ticketMedioGeral = totalPedidos > 0 ? parseFloat((totalFaturado / totalPedidos).toFixed(2)) : 0;
+
+    return successResponse(res, {
+      dataInicio,
+      dataFim,
+      daily,
+      kpis: {
+        totalFaturado: parseFloat(totalFaturado.toFixed(2)),
+        totalPedidos,
+        ticketMedio: ticketMedioGeral,
+        diasComVenda: daily.length,
+      },
+    });
+  } catch (err) {
+    return errorResponse(res, 502, 'Erro ao buscar faturamento na Mobne.', err.message);
+  }
+}

--- a/frontend/src/components/Reports/BillingChart.jsx
+++ b/frontend/src/components/Reports/BillingChart.jsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import api from '../../services/api.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Tooltip, Legend);
+
+function fmt(value) {
+  return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function toDateInput(isoDate) {
+  return isoDate.slice(0, 10);
+}
+
+function defaultRange() {
+  const end = new Date();
+  const start = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000);
+  return {
+    dataInicio: toDateInput(start.toISOString()),
+    dataFim: toDateInput(end.toISOString()),
+  };
+}
+
+export function BillingChart() {
+  const [range, setRange] = useState(defaultRange());
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  function fetchBilling(dataInicio, dataFim) {
+    setLoading(true);
+    setError(null);
+    api
+      .get('/reports/billing', { params: { dataInicio, dataFim } })
+      .then(({ data: res }) => setData(res))
+      .catch((err) => setError(err.response?.data?.error || 'Erro ao carregar faturamento.'))
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    fetchBilling(range.dataInicio, range.dataFim);
+  }, []);
+
+  function handleApply() {
+    fetchBilling(range.dataInicio, range.dataFim);
+  }
+
+  const chartData = {
+    labels: (data?.daily || []).map((d) =>
+      new Date(d.date + 'T12:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
+    ),
+    datasets: [
+      {
+        label: 'Faturamento (R$)',
+        data: (data?.daily || []).map((d) => d.total),
+        backgroundColor: '#2563eb',
+        borderRadius: 4,
+        borderSkipped: false,
+      },
+    ],
+  };
+
+  const chartOptions = {
+    responsive: true,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (ctx) => ` ${fmt(ctx.parsed.y)}`,
+          afterLabel: (ctx) => {
+            const day = data?.daily?.[ctx.dataIndex];
+            return day ? ` ${day.count} pedidos · TM: ${fmt(day.ticketMedio)}` : '';
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (v) => `R$ ${v.toLocaleString('pt-BR')}`,
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Filtro de período */}
+      <div className="card flex flex-wrap items-end gap-4">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Data início</label>
+          <input
+            type="date"
+            value={range.dataInicio}
+            max={range.dataFim}
+            onChange={(e) => setRange((r) => ({ ...r, dataInicio: e.target.value }))}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Data fim</label>
+          <input
+            type="date"
+            value={range.dataFim}
+            min={range.dataInicio}
+            max={toDateInput(new Date().toISOString())}
+            onChange={(e) => setRange((r) => ({ ...r, dataFim: e.target.value }))}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <button
+          onClick={handleApply}
+          disabled={loading}
+          className="btn-primary text-sm px-5 py-2"
+        >
+          {loading ? 'Carregando...' : 'Aplicar'}
+        </button>
+      </div>
+
+      {/* KPIs */}
+      {data && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <KpiCard label="Total Faturado" value={fmt(data.kpis.totalFaturado)} color="text-blue-700" />
+          <KpiCard label="Pedidos" value={data.kpis.totalPedidos.toLocaleString('pt-BR')} />
+          <KpiCard label="Ticket Médio" value={fmt(data.kpis.ticketMedio)} color="text-green-600" />
+          <KpiCard label="Dias com Venda" value={data.kpis.diasComVenda.toString()} color="text-purple-600" />
+        </div>
+      )}
+
+      {/* Gráfico */}
+      <div className="card">
+        <h4 className="font-medium text-gray-700 mb-4">Faturamento Diário</h4>
+        {loading && <div className="text-gray-400 text-sm text-center py-12">Carregando...</div>}
+        {error && <div className="text-red-500 text-sm text-center py-12">{error}</div>}
+        {!loading && !error && data?.daily?.length === 0 && (
+          <div className="text-gray-400 text-sm text-center py-12">Nenhum pedido encontrado no período.</div>
+        )}
+        {!loading && !error && data?.daily?.length > 0 && (
+          <Bar data={chartData} options={chartOptions} />
+        )}
+      </div>
+
+      {/* Tabela diária */}
+      {!loading && data?.daily?.length > 0 && (
+        <div className="card overflow-x-auto">
+          <h4 className="font-medium text-gray-700 mb-4">Detalhamento por Dia</h4>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100 text-left text-gray-500">
+                <th className="pb-2 font-medium">Data</th>
+                <th className="pb-2 font-medium text-right">Pedidos</th>
+                <th className="pb-2 font-medium text-right">Ticket Médio</th>
+                <th className="pb-2 font-medium text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.daily.map((d) => (
+                <tr key={d.date} className="border-b border-gray-50 hover:bg-gray-50">
+                  <td className="py-2 text-gray-700">
+                    {new Date(d.date + 'T12:00:00').toLocaleDateString('pt-BR')}
+                  </td>
+                  <td className="py-2 text-right text-gray-600">{d.count}</td>
+                  <td className="py-2 text-right text-gray-600">{fmt(d.ticketMedio)}</td>
+                  <td className="py-2 text-right font-semibold text-blue-700">{fmt(d.total)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function KpiCard({ label, value, color = 'text-primary-700' }) {
+  return (
+    <div className="card text-center">
+      <div className={`text-2xl font-bold ${color}`}>{value}</div>
+      <div className="text-xs text-gray-500 mt-1">{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import { DashboardLayout } from '../components/Dashboard/DashboardLayout.jsx';
 import { SalesReport } from '../components/Reports/SalesReport.jsx';
 import { MetricsChart } from '../components/Reports/MetricsChart.jsx';
+import { BillingChart } from '../components/Reports/BillingChart.jsx';
 
 export default function ReportsPage() {
-  const [tab, setTab] = useState('metrics');
+  const [tab, setTab] = useState('billing');
 
   return (
     <DashboardLayout>
@@ -18,6 +19,7 @@ export default function ReportsPage() {
         <div className="border-b border-gray-200">
           <div className="flex gap-4">
             {[
+              { key: 'billing', label: 'Faturamento Diário' },
               { key: 'metrics', label: 'Métricas e Gráficos' },
               { key: 'sales', label: 'Relatório de Dados' },
             ].map(({ key, label }) => (
@@ -36,6 +38,7 @@ export default function ReportsPage() {
           </div>
         </div>
 
+        {tab === 'billing' && <BillingChart />}
         {tab === 'metrics' && <MetricsChart />}
         {tab === 'sales' && <SalesReport />}
       </div>

--- a/lib/mobneClient.js
+++ b/lib/mobneClient.js
@@ -8,6 +8,7 @@ export const MOBNE_ENDPOINTS = {
   produtos: 'Produto/consulta-cadastro-produto',
   notas: 'Nota/consulta',
   empresas: 'Empresa/consulta-cadastro-empresa',
+  pedidosVenda: 'PedidoVenda',
 };
 
 /**
@@ -36,7 +37,7 @@ function mockResponse(path, params) {
  * Em produção (Vercel), fetch funciona normalmente — substituir por fetch padrão.
  * Retorna dados mock se MOBNE_API_KEY não estiver configurada.
  */
-function mobneRequest(path, params = {}) {
+function mobneRequest(path, params = {}, extraHeaders = {}) {
   if (!MOBNE_API_KEY) {
     return mockResponse(path, params);
   }
@@ -44,9 +45,15 @@ function mobneRequest(path, params = {}) {
   const query = new URLSearchParams(params).toString();
   const url = `${MOBNE_BASE_URL}/${path}${query ? `?${query}` : ''}`;
 
+  const headerArgs = [];
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headerArgs.push('-H', `${key}: ${value}`);
+  }
+
   const result = spawnSync('curl', [
     '-s', '-f',
     '-H', `Authorization: ApiKey ${MOBNE_API_KEY}`,
+    ...headerArgs,
     url,
   ], { encoding: 'utf8', timeout: 30000 });
 
@@ -91,8 +98,8 @@ export async function fetchAllPages(endpoint, extraParams = {}, maxPages = 0) {
 /**
  * Busca uma página específica de um endpoint Mobne.
  */
-export function fetchPage(endpoint, pageNumber = 1, pageSize = 100, extraParams = {}) {
+export function fetchPage(endpoint, pageNumber = 1, pageSize = 100, extraParams = {}, extraHeaders = {}) {
   const path = MOBNE_ENDPOINTS[endpoint];
   if (!path) throw new Error(`Endpoint Mobne desconhecido: ${endpoint}`);
-  return mobneRequest(path, { PageSize: pageSize, PageNumber: pageNumber, ...extraParams });
+  return mobneRequest(path, { PageSize: pageSize, PageNumber: pageNumber, ...extraParams }, extraHeaders);
 }


### PR DESCRIPTION
- Adiciona endpoint /api/reports/billing com filtro de período (dataInicio/dataFim)
- Agrupa pedidos por dia e calcula totalFaturado, totalPedidos, ticketMédio
- Suporte a paginação automática e mock quando MOBNE_API_KEY não configurada
- Cria componente BillingChart com gráfico de barras, KPIs e tabela diária
- Adiciona aba 'Faturamento Diário' como padrão em ReportsPage
- Adiciona endpoint pedidosVenda ao mobneClient e suporte a headers extras