### PR TITLE
Sistema de preços: revisão do PRD, PRD v2 e implementação das fases 1 e 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@ frontend/dist/
 .env.*.local
 *.log
 .DS_Store
+
+# Python (monitor de preços)
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+*.db
+*.db-wal
+*.db-shm

--- a/docs/PRD_PRECOS_V2.md
+++ b/docs/PRD_PRECOS_V2.md
@@ -1,0 +1,394 @@
+# PRD v2.0 — Sistema de Monitoramento e Comparação de Preços
+
+**Status:** Proposta de correção da v1.0
+**Base:** [`REVIEW_PRD_PRECOS.md`](./REVIEW_PRD_PRECOS.md)
+**Stack:** Python 3.10+ / SQLite (mantido da v1.0)
+
+Este documento reescreve as partes da v1.0 que a revisão apontou como quebradas. O que não aparece
+aqui permanece como estava.
+
+---
+
+## 1. Mudanças de conceito em relação à v1.0
+
+| v1.0 | v2.0 | Por quê |
+|------|------|---------|
+| Preço de referência é uma coluna digitada na planilha | Preço de referência é **derivado do histórico** (mediana / p25 dos últimos 90 dias); a planilha vira uma fonte a mais | Régua estática envelhece em dias |
+| Tabela por fonte (`ofertas_ifood`) | `fontes` + `lojas` + `ofertas` genéricas | A v1 já nasce precisando de 2 fontes |
+| Oferta e pareamento na mesma linha | Coleta bruta imutável + `matches` separado | Permite re-rodar o matcher sobre dados já coletados |
+| Corte único de similaridade em 85 | Três faixas + **portão de unidade** + aliases aprendidos | Fuzzy sozinho casa 200g com 500g |
+| Alerta sem regra definida | Regra explícita com 4 condições e cooldown | O F05 da v1 estava em branco |
+| Preços em `REAL` | Inteiro em centavos | Erro de ponto flutuante em agregações |
+
+---
+
+## 2. Esquema de banco de dados
+
+> Validado: este DDL foi executado sem erros em **SQLite 3.45.1**, e as constraints abaixo foram
+> testadas — o índice único parcial aceita múltiplos produtos sem EAN, rejeita EAN duplicado, e a
+> FK é efetivamente aplicada com `PRAGMA foreign_keys = ON`.
+
+```sql
+PRAGMA foreign_keys = ON;   -- OBRIGATÓRIO em toda conexão: no SQLite vem desligado por padrão
+PRAGMA journal_mode = WAL;
+
+-- ============================================================
+-- DIMENSÕES
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS fontes (
+    id            INTEGER PRIMARY KEY,
+    slug          TEXT NOT NULL UNIQUE,
+    nome          TEXT NOT NULL,
+    tipo          TEXT NOT NULL CHECK (tipo IN ('marketplace', 'varejo_online', 'planilha', 'orgao_publico')),
+    ativa         INTEGER NOT NULL DEFAULT 1 CHECK (ativa IN (0, 1)),
+    criada_em     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Preço é sempre um fato de (produto, LOJA, momento) — nunca um atributo do produto.
+CREATE TABLE IF NOT EXISTS lojas (
+    id             INTEGER PRIMARY KEY,
+    fonte_id       INTEGER NOT NULL REFERENCES fontes(id) ON DELETE CASCADE,
+    codigo_externo TEXT,
+    nome           TEXT NOT NULL,
+    cidade         TEXT,
+    uf             TEXT CHECK (uf IS NULL OR length(uf) = 2),
+    latitude       REAL,
+    longitude      REAL,
+    criada_em      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (fonte_id, codigo_externo)
+);
+
+-- id surrogate: hortifruti/granel não têm EAN e precisam existir na base.
+-- quantidade+unidade são CAMPOS, não texto — é o que viabiliza o portão de unidade do matcher.
+CREATE TABLE IF NOT EXISTS produtos (
+    id            INTEGER PRIMARY KEY,
+    ean           TEXT,
+    nome          TEXT NOT NULL,
+    marca         TEXT,
+    categoria     TEXT,
+    quantidade    REAL,                    -- sempre normalizada para a unidade base
+    unidade       TEXT CHECK (unidade IS NULL OR unidade IN ('g', 'ml', 'un')),
+    monitorado    INTEGER NOT NULL DEFAULT 1 CHECK (monitorado IN (0, 1)),
+    criado_em     TEXT NOT NULL DEFAULT (datetime('now')),
+    atualizado_em TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Índice único PARCIAL: garante EAN único quando existe, e permite N produtos sem EAN.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_produtos_ean
+    ON produtos(ean) WHERE ean IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_produtos_marca ON produtos(marca);
+CREATE INDEX IF NOT EXISTS ix_produtos_monitorado ON produtos(monitorado) WHERE monitorado = 1;
+
+-- ============================================================
+-- EXECUÇÕES — mesmo padrão de sync_logs em database/migrations/001_init.sql
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS execucoes (
+    id              INTEGER PRIMARY KEY,
+    fonte_id        INTEGER REFERENCES fontes(id) ON DELETE SET NULL,
+    tipo            TEXT NOT NULL CHECK (tipo IN ('watchlist', 'catalogo', 'manual', 'import')),
+    status          TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+    itens_coletados INTEGER NOT NULL DEFAULT 0,
+    erro            TEXT,
+    iniciada_em     TEXT NOT NULL DEFAULT (datetime('now')),
+    concluida_em    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ix_execucoes_fonte_data ON execucoes(fonte_id, iniciada_em DESC);
+
+-- ============================================================
+-- FATO: OFERTAS BRUTAS (append-only, imutável)
+-- Sem FK para produtos: a oferta é gravada SEMPRE, mesmo sem pareamento.
+-- payload_bruto permite re-parsear histórico sem re-coletar.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ofertas (
+    id                INTEGER PRIMARY KEY,
+    execucao_id       INTEGER NOT NULL REFERENCES execucoes(id) ON DELETE CASCADE,
+    loja_id           INTEGER NOT NULL REFERENCES lojas(id) ON DELETE CASCADE,
+    titulo_original   TEXT NOT NULL,
+    ean_informado     TEXT,
+    preco_centavos    INTEGER NOT NULL CHECK (preco_centavos > 0),
+    preco_de_centavos INTEGER CHECK (preco_de_centavos IS NULL OR preco_de_centavos > 0),
+    disponivel        INTEGER NOT NULL DEFAULT 1 CHECK (disponivel IN (0, 1)),
+    url               TEXT,
+    payload_bruto     TEXT,
+    coletada_em       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_ofertas_execucao  ON ofertas(execucao_id);
+CREATE INDEX IF NOT EXISTS ix_ofertas_loja_data ON ofertas(loja_id, coletada_em DESC);
+CREATE INDEX IF NOT EXISTS ix_ofertas_ean       ON ofertas(ean_informado) WHERE ean_informado IS NOT NULL;
+
+-- ============================================================
+-- PAREAMENTO
+-- ============================================================
+
+-- Cada confirmação humana vira memória permanente. É a camada que faz o sistema
+-- ficar mais preciso com o uso, em vez de repetir o mesmo fuzzy para sempre.
+CREATE TABLE IF NOT EXISTS produto_aliases (
+    id             INTEGER PRIMARY KEY,
+    produto_id     INTEGER NOT NULL REFERENCES produtos(id) ON DELETE CASCADE,
+    fonte_id       INTEGER NOT NULL REFERENCES fontes(id) ON DELETE CASCADE,
+    titulo_norm    TEXT NOT NULL,
+    confirmado_por TEXT NOT NULL DEFAULT 'humano',
+    criado_em      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (fonte_id, titulo_norm)
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+    id         INTEGER PRIMARY KEY,
+    oferta_id  INTEGER NOT NULL REFERENCES ofertas(id) ON DELETE CASCADE,
+    produto_id INTEGER REFERENCES produtos(id) ON DELETE SET NULL,
+    metodo     TEXT NOT NULL CHECK (metodo IN ('alias', 'ean', 'fuzzy')),
+    score      REAL CHECK (score IS NULL OR (score >= 0 AND score <= 100)),
+    status     TEXT NOT NULL CHECK (status IN ('auto', 'revisar', 'confirmado', 'rejeitado')),
+    criado_em  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (oferta_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_matches_produto ON matches(produto_id);
+CREATE INDEX IF NOT EXISTS ix_matches_revisar ON matches(status) WHERE status = 'revisar';
+
+-- ============================================================
+-- FATO: SÉRIE HISTÓRICA — o ativo do projeto
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS precos_coletados (
+    id                INTEGER PRIMARY KEY,
+    produto_id        INTEGER NOT NULL REFERENCES produtos(id) ON DELETE CASCADE,
+    loja_id           INTEGER NOT NULL REFERENCES lojas(id) ON DELETE CASCADE,
+    oferta_id         INTEGER REFERENCES ofertas(id) ON DELETE SET NULL,
+    preco_centavos    INTEGER NOT NULL CHECK (preco_centavos > 0),
+    preco_por_unidade REAL,               -- R$/kg ou R$/L: torna embalagens comparáveis
+    coletado_em       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_precos_produto_data ON precos_coletados(produto_id, coletado_em DESC);
+CREATE INDEX IF NOT EXISTS ix_precos_loja_data    ON precos_coletados(loja_id, coletado_em DESC);
+
+-- ============================================================
+-- ALERTAS — alert_key UNIQUE é o que impede spam
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS alertas (
+    id                  INTEGER PRIMARY KEY,
+    alert_key           TEXT NOT NULL UNIQUE,
+    produto_id          INTEGER NOT NULL REFERENCES produtos(id) ON DELETE CASCADE,
+    loja_id             INTEGER NOT NULL REFERENCES lojas(id) ON DELETE CASCADE,
+    oferta_id           INTEGER REFERENCES ofertas(id) ON DELETE SET NULL,
+    preco_centavos      INTEGER NOT NULL,
+    referencia_centavos INTEGER NOT NULL,
+    economia_pct        REAL NOT NULL,
+    economia_centavos   INTEGER NOT NULL,
+    enviado_em          TEXT NOT NULL DEFAULT (datetime('now')),
+    feedback            TEXT CHECK (feedback IS NULL OR feedback IN ('util', 'irrelevante', 'errado'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_alertas_produto_data ON alertas(produto_id, enviado_em DESC);
+```
+
+### 2.1 Preço de referência derivado
+
+Substitui a coluna `preco_referencia` da v1. Mediana e p25 dos últimos 90 dias, via window function
+(testado — o SQLite não tem `MEDIAN` nativo):
+
+```sql
+WITH r AS (
+  SELECT preco_centavos,
+         PERCENT_RANK() OVER (ORDER BY preco_centavos) AS pr
+  FROM precos_coletados
+  WHERE produto_id = :produto_id
+    AND coletado_em >= datetime('now', '-90 days')
+)
+SELECT MAX(CASE WHEN pr <= 0.50 THEN preco_centavos END) AS mediana_centavos,
+       MAX(CASE WHEN pr <= 0.25 THEN preco_centavos END) AS p25_centavos
+FROM r;
+```
+
+**Regra de referência:** use a mediana como régua principal. Se houver menos de 5 amostras nos 90
+dias, caia para o preço da planilha do usuário — e marque o alerta como "referência fraca".
+
+---
+
+## 3. Motor de pareamento (F04 revisado)
+
+### 3.1 Pipeline em 5 estágios
+
+```
+título bruto da fonte
+   │
+   ├─ 1. NORMALIZAR ──────► minúsculas, sem acentos, abreviações expandidas
+   │                        ("int"→integral, "ref"→refrigerante), ruído removido
+   │
+   ├─ 2. EXTRAIR ─────────► marca | quantidade | unidade viram campos
+   │                        "Leite Italac Integral 1L" → {italac, 1000, ml}
+   │
+   ├─ 3. ALIAS ───────────► produto_aliases[fonte, titulo_norm] → HIT? fim (determinístico)
+   │
+   ├─ 4. EAN ─────────────► ean_informado casa em produtos.ean → HIT? fim
+   │
+   └─ 5. FUZZY ───────────► candidatos = produtos da MESMA MARCA (blocking)
+                            score = fuzz.token_set_ratio(nome_sem_quantidade)
+                            ⛔ PORTÃO: quantidade convertida DEVE bater — senão rejeita,
+                               por mais alto que seja o score
+```
+
+**O portão de unidade é uma regra dura, não um peso.** É ele — e não o threshold — que resolve o
+falso positivo 200g × 500g apontado na seção 6 da v1. Um score de 97 entre "Leite Italac 1L" e
+"Leite Italac 200ml" é rejeitado sem apelação.
+
+### 3.2 Três faixas em vez de um corte
+
+| Faixa | Ação | `matches.status` |
+|-------|------|------------------|
+| score ≥ `LIMITE_AUTO` **e** unidade bate | aceita e pode alertar | `auto` |
+| `LIMITE_REVISAR` ≤ score < `LIMITE_AUTO` | entra na fila de revisão manual, **não alerta** | `revisar` |
+| score < `LIMITE_REVISAR` | descarta | `rejeitado` |
+
+Toda confirmação na fila de revisão grava um registro em `produto_aliases` — o título nunca mais
+passa pelo fuzzy. Com o tempo, o estágio 3 absorve a maior parte do tráfego e o sistema fica
+determinístico onde importa.
+
+### 3.3 Como calibrar os limites (não chute)
+
+O `85` da v1 é um número escolhido a priori. O procedimento mínimo:
+
+1. Colete ~200 pares reais (título da fonte × produto da base), variados: mesma marca com gramaturas
+   diferentes, marcas concorrentes do mesmo item, sabores/variantes.
+2. Rotule à mão: match / não-match.
+3. Rode a pipeline variando o limite e meça **precisão** e **recall** em cada ponto.
+4. Escolha `LIMITE_AUTO` pelo alvo de precisão, não pelo de recall.
+
+**Alvo sugerido: precisão ≥ 98% no aceite automático.** Em alerta de compra, falso positivo custa
+muito mais que falso negativo — perder uma oferta é chato; mandar o usuário comprar a coisa errada
+destrói a confiança no sistema inteiro. Guarde o conjunto rotulado no repositório e rode-o como
+teste de regressão sempre que mexer no matcher.
+
+---
+
+## 4. Motor de alertas (F05 — a regra que faltava)
+
+Um alerta é disparado quando **todas** as condições valem:
+
+| # | Condição | Motivo |
+|---|----------|--------|
+| 1 | `preco ≤ referencia × (1 − DESCONTO_MIN_PCT)` | o desconto percentual que importa |
+| 2 | `economia_centavos ≥ ECONOMIA_MIN_CENTAVOS` | evita alertar R$ 0,30 num item de R$ 3,00 |
+| 3 | `preco ≥ referencia × PISO_SANIDADE` | queda de 95% é erro de parsing, não oferta |
+| 4 | `match.status IN ('auto','confirmado')` | nunca alerta sobre pareamento não verificado |
+| 5 | nenhum alerta com o mesmo `alert_key` na janela de cooldown | impede repetir a cada execução |
+| 6 | `oferta.disponivel = 1` | não alerta produto esgotado |
+
+```python
+alert_key = sha256(f"{produto_id}|{loja_id}|{preco_centavos // 50}")  # faixas de R$ 0,50
+```
+
+Agrupar o preço em faixas no `alert_key` evita que uma oscilação de um centavo seja tratada como
+oferta nova.
+
+**Parâmetros iniciais sugeridos** (todos em arquivo de config, para ajuste sem deploy):
+
+| Parâmetro | Valor inicial |
+|-----------|---------------|
+| `DESCONTO_MIN_PCT` | 15% |
+| `ECONOMIA_MIN_CENTAVOS` | 200 (R$ 2,00) |
+| `PISO_SANIDADE` | 0,30 (rejeita quedas > 70%) |
+| `COOLDOWN_HORAS` | 48 |
+| `MAX_ALERTAS_DIA` | 10 |
+
+`MAX_ALERTAS_DIA` é um teto rígido: se estourar, envie um resumo único em vez de mensagens
+separadas. Fadiga de alerta mata este produto mais rápido que scraper quebrado.
+
+### 4.1 Frete e pedido mínimo
+
+Comparar preço de item entre um marketplace com entrega e um supermercado é comparação incompleta:
+R$ 2,00 de economia com R$ 9,99 de taxa é prejuízo de R$ 7,99. Duas saídas, em ordem de esforço:
+
+- **Mínimo:** a mensagem de alerta declara a taxa de entrega e o pedido mínimo da loja, e diz
+  explicitamente "vale se você já for pedir outros itens".
+- **Correto:** avaliar no nível de **cesta** — acumular ofertas por loja e só alertar quando a soma
+  das economias superar a taxa de entrega.
+
+Comece pelo mínimo; a cesta depende de ter várias fontes ativas.
+
+---
+
+## 5. Estrutura de código
+
+```
+precos/
+├── cli.py                    # ponto de entrada: importar / coletar / parear / alertar / revisar
+├── config.py                 # thresholds e parâmetros de alerta (sem números mágicos no código)
+├── storage/
+│   ├── schema.sql            # o DDL da seção 2
+│   ├── db.py                 # conexão (com PRAGMA foreign_keys=ON), migrations
+│   └── repositories.py       # queries nomeadas; nenhum SQL solto pelo resto do código
+├── normalize/
+│   ├── precos.py             # parse_preco_brl() — UMA função, com testes
+│   ├── quantidades.py        # parse_quantidade() → (valor, unidade) normalizados
+│   └── texto.py              # normalizar_titulo(), expandir_abreviacoes()
+├── collectors/
+│   ├── base.py               # interface comum: coletar() -> list[OfertaBruta]
+│   ├── vtex.py               # cliente do JSON público (serve Mambo, Pão de Açúcar, …)
+│   └── planilha.py           # importador CSV/XLSX
+├── matching/
+│   ├── pipeline.py           # os 5 estágios da seção 3.1
+│   ├── aliases.py            # leitura/escrita de produto_aliases
+│   └── avaliacao.py          # precisão/recall sobre o conjunto rotulado
+├── alerts/
+│   ├── regras.py             # as 6 condições da seção 4
+│   └── telegram.py           # envio
+└── tests/
+    ├── test_precos.py        # "R$ 1.234,56", "R$ 12,34", "R$ 9,90/kg", NBSP, centavos em <sup>
+    ├── test_quantidades.py   # "1L", "200g", "2x500ml", "1,5 L", "kg"
+    └── fixtures/pares.csv    # conjunto rotulado (seção 3.3)
+```
+
+**Três regras que evitam a maior parte dos bugs da v1:**
+
+1. **Parsing em um lugar só.** `parse_preco_brl` e `parse_quantidade` são funções únicas, testadas,
+   usadas por todos os coletores. Na v1 o parsing de preço estava inline no scraper — cada nova
+   fonte reescreveria (e reintroduziria) o mesmo bug.
+2. **Coletor não escreve no banco.** Retorna `list[OfertaBruta]`; quem persiste é o repositório.
+   Torna cada coletor testável sem banco.
+3. **Nenhum limiar hardcoded.** Todos em `config.py` — porque a seção 3.3 vai mudá-los depois de
+   medir.
+
+### 5.1 Health check obrigatório do coletor
+
+O modo de falha mais perigoso é coletar zero itens em silêncio e parecer "não teve oferta hoje":
+
+```python
+if len(ofertas) < PISO_ESPERADO[fonte]:
+    registrar_execucao(status='failed', erro=f'coleta anômala: {len(ofertas)} itens')
+    notificar_operador()      # falha ALTO, não grava vazio
+    return
+```
+
+---
+
+## 6. Roadmap
+
+| # | Entrega | Depende de |
+|---|---------|-----------|
+| 1 | Schema + importador de planilha (F01) | — |
+| 2 | Coletor VTEX de 1 varejista, via JSON público (F02) | 1 |
+| 3 | Série histórica + preço de referência derivado | 2 |
+| 4 | Pipeline de matching com portão de unidade + aliases (F04) | 3 |
+| 5 | Conjunto rotulado + calibração dos limites | 4 |
+| 6 | Alertas com regra, dedupe e cooldown (F05) | 5 |
+| 7 | Segundo varejista | 4 |
+| 8 | iFood — apenas pelos caminhos legítimos da revisão, §5.1 | 6 |
+
+Os passos 1–7 entregam um comparador de preços de varejo completo e defensável. O iFood deixa de ser
+pré-requisito e vira incremento.
+
+---
+
+## 7. Backup
+
+A série histórica é o ativo do projeto e leva meses para ser reconstruída — se é que pode. Cópia
+automatizada do arquivo `.db` para fora da máquina desde o primeiro dia, usando a API de backup
+online do SQLite (`sqlite3.Connection.backup()`), que é consistente com o banco em uso.

--- a/docs/PRD_SISTEMA_PRECOS_COMPLETO.md
+++ b/docs/PRD_SISTEMA_PRECOS_COMPLETO.md
@@ -1,0 +1,377 @@
+# PRD — Sistema de Monitoramento e Comparação de Preços de Supermercado
+
+**Versão:** 2.1 (consolidado)
+**Status:** Fases 1–3 implementadas e testadas · Fases 4–8 especificadas, não implementadas
+**Stack:** Python 3.10+ / SQLite (padrão) — deploy em Vercel é decisão em aberto (§9)
+**Documentos-fonte:** [`REVIEW_PRD_PRECOS.md`](./REVIEW_PRD_PRECOS.md) (crítica da v1) · [`PRD_PRECOS_V2.md`](./PRD_PRECOS_V2.md) (design v2) · código em [`precos/`](../precos/)
+
+Este arquivo é o ponto único de referência: reúne visão de produto, decisões de arquitetura, o que já roda de verdade e o que ainda é só especificação — organizado pelas fases do roadmap.
+
+---
+
+## 1. Visão e objetivo
+
+Monitorar, comparar e alertar sobre produtos de supermercado com preço abaixo do praticado no varejo tradicional ou abaixo de uma planilha de referência do usuário — com leitura por EAN quando disponível e pareamento textual quando não.
+
+**Origem:** um PRD v1.0 trazia essa visão mas com um defeito estrutural (schema sem histórico de preços — só sabia comparar contra um número digitado) e um item fora do que este projeto está disposto a fazer (contornar proteção antibot do iFood). A v2 corrige o schema e resolve a coleta por fontes legítimas; este documento consolida v2 + implementação.
+
+## 2. Decisões de arquitetura confirmadas
+
+| Decisão | Escolha | Onde foi definida |
+|---|---|---|
+| Linguagem/armazenamento | Python 3.10+ / SQLite | Mantido por escolha explícita do usuário sobre a v1 |
+| Coleta do iFood | **Não** via bypass de antibot | Recusa registrada em `REVIEW_PRD_PRECOS.md` §5.1 |
+| Fonte de varejo | Catálogo público VTEX (JSON), não scraping de DOM | `REVIEW_PRD_PRECOS.md` §5.1(a) |
+| Preço de referência | Derivado do histórico (mediana/p25 de 90 dias), não campo digitado | `PRD_PRECOS_V2.md` §2.1 |
+| Deploy web/Vercel | **Em aberto** — Node vs. Python vs. híbrido | §9 deste documento |
+
+## 3. Arquitetura de dados
+
+Preço é sempre um fato de **(produto, loja, momento)** — nunca um atributo do produto. Esse princípio único evita a maior parte dos defeitos encontrados na v1 (ver §10).
+
+```
+fontes ──┬── lojas ──┬── ofertas (bruto, imutável, append-only)
+         │           │       │
+         │           │       └── matches (produto_id, score, método, status)
+         │           │
+         │           └── precos_coletados (fato histórico, centavos)
+         │
+produtos ─┴── produto_aliases (título da fonte → produto, aprendido)
+
+execucoes  (log de toda coleta/importação — sucesso ou falha)
+alertas    (alert_key único, cooldown)
+```
+
+Schema completo, comentado e **validado** (executado em SQLite 3.45.1, constraints testadas): [`PRD_PRECOS_V2.md` §2](./PRD_PRECOS_V2.md#2-esquema-de-banco-de-dados).
+
+---
+
+## 4. Roadmap por fases
+
+| # | Fase | Entrega | Status |
+|---|------|---------|--------|
+| 1 | Schema + importador de planilha | F01 | ✅ Implementado e testado |
+| 2 | Coletor VTEX | F02 | ✅ Implementado e testado |
+| 3 | Série histórica + referência derivada | — | ✅ Implementado (veio junto das fases 1–2) |
+| 4 | Matching com portão de unidade | F04 | ⬜ Especificado, não implementado |
+| 5 | Calibração do threshold | — | ⬜ Especificado, não implementado |
+| 6 | Alertas (regra + dedupe + cooldown) | F05 | ⬜ Especificado, não implementado |
+| 7 | Segundo varejista | — | ⬜ Não iniciado |
+| 8 | iFood (só caminhos legítimos) | F03 | ⬜ Bloqueado até 4–6 existirem |
+| 9 | Deploy web (Vercel) | — | ⬜ Decisão de stack em aberto |
+
+Os passos 1–7 entregam um comparador de preços de varejo completo e defensável **sem depender do iFood**. O iFood é incremento, não pré-requisito.
+
+---
+
+## Fase 1 — Schema + importador de planilha (F01) ✅
+
+**Status:** implementado, testado, exercitado ponta a ponta.
+
+### O que faz
+
+- Cria e migra o banco (`precos.cli migrar`), com `PRAGMA foreign_keys = ON` obrigatório em toda conexão — no SQLite essa checagem vem desligada por padrão, e sem ela as FKs do schema seriam decorativas (era exatamente o defeito da v1).
+- Lê planilha `.csv` (biblioteca padrão) ou `.xlsx` (openpyxl opcional) e importa produtos + preços.
+- Aceita tanto `Preco_Referencia` quanto `Preco` como nome de coluna — a v1 divergia de si mesma nesse ponto (spec dizia um, código lia outro).
+- Normaliza EAN corrompido pelo Excel (`7891234567890.0`, notação científica) e valida o dígito verificador GTIN.
+- Extrai quantidade/unidade do próprio nome do produto (`"Leite Italac 1L"` → 1000ml).
+- Linha com preço ilegível é **descartada com motivo registrado**, nunca gravada como `NaN` silencioso.
+- Produto sem EAN (hortifruti, açougue, granel) é aceito normalmente — a v1 usava `ean` como `PRIMARY KEY` e excluía esses itens.
+
+### Módulos
+
+```
+precos/
+├── config.py                  parâmetros (nada hardcoded no código)
+├── storage/
+│   ├── schema.sql              DDL — extraído e validado do PRD v2
+│   ├── db.py                    conexão, migração idempotente, backup
+│   └── repositories.py          todo o SQL do sistema, num só lugar
+├── normalize/
+│   ├── precos.py                parse_preco_brl() → centavos (int)
+│   ├── quantidades.py           parse_quantidade(), extrair_do_titulo()
+│   └── texto.py                 normalizar_titulo(), normalizar_ean(), validar_ean()
+└── collectors/
+    └── planilha.py               leitura CSV/XLSX
+```
+
+### Uso
+
+```bash
+python -m precos.cli migrar
+python -m precos.cli importar precos/exemplos/planilha_exemplo.csv
+```
+
+### Verificação feita
+
+- Planilha de 7 linhas importada de ponta a ponta: 6 produtos criados (incluindo 2 sem EAN — banana e tomate), 1 linha com preço vazio descartada com motivo.
+- Reimportar a mesma planilha: **0 produtos novos, histórico acumula** (2 observações por produto) em vez de sobrescrever — o defeito central da v1 (`INSERT OR REPLACE` apagando o preço anterior) está corrigido e coberto por teste (`test_storage.py::test_historico_preserva_todas_as_observacoes`).
+- Quantidades extraídas corretamente: `2x400g` → 800g, `5kg` → 5000g, `kg` (produto a peso) → 1000g.
+
+---
+
+## Fase 2 — Coletor VTEX (F02) ✅
+
+**Status:** implementado, testado offline (sem tocar rede real). **Não verificado contra loja real** (ver §8).
+
+### Por que VTEX e não scraping de DOM
+
+Mambo roda VTEX (confirmado via pesquisa: `mambo.myvtex.com`). O endpoint público `/api/catalog_system/pub/products/search` devolve JSON estruturado com produto, SKU, EAN e oferta por seller. Os seletores da v1 (`vtex-product-summary-2-x-container`) carregam a versão do componente no nome — uma atualização de tema muda o número e o scraper passa a devolver lista vazia **sem erro**.
+
+### O que faz
+
+- Pagina o catálogo por janela inclusiva (`_from`/`_to`), com deduplicação entre páginas.
+- Backoff exponencial em erro de rede ou 5xx/429; falha alto (não repete) em 4xx que não seja 429.
+- Cada SKU de um produto (embalagens diferentes) vira uma oferta separada — colapsar aqui reintroduziria a confusão de gramatura pelo outro lado.
+- `preco_de` só é gravado quando é desconto real (`ListPrice > Price`) — evita "desconto fantasma" quando de=por.
+- **Health check obrigatório**: coleta abaixo de `piso_esperado` levanta `ColetaAnomala` e a execução é marcada `failed`. É o modo de falha mais perigoso do sistema — coletar zero item em silêncio e parecer "não teve oferta hoje" — tratado como erro, não como resultado.
+- Sessão HTTP é injetável por construtor, o que mantém os testes 100% offline.
+
+### Uso
+
+```bash
+python -m precos.cli coletar mambo --limite 200
+```
+
+### Verificação feita
+
+30 testes cobrindo: extração de campos, preço-de sem desconto real ignorado, SKUs distintos viram ofertas distintas, paginação (janela inclusiva, limite respeitado, dedupe entre páginas, categorias geram consultas separadas), health check (coleta vazia e coleta abaixo do piso falham alto), e tratamento de HTTP (404 não repete, 500 repete e desiste após `MAX_TENTATIVAS`, 206 é tratado como sucesso — resposta normal da busca paginada VTEX).
+
+Fluxo ponta a ponta com sessão HTTP simulada (3 produtos, incluindo um com desconto real): 3 ofertas gravadas, 3 com EAN, execução registrada como `completed`.
+
+---
+
+## Fase 3 — Série histórica + referência derivada ✅
+
+**Status:** implementado (veio embutido nas fases 1 e 2, não é um passo separado de código).
+
+### O que faz
+
+Substitui a coluna `preco_referencia` sobrescrevível da v1. Toda observação de preço — de planilha ou de coleta — vira uma linha em `precos_coletados` (fato, append-only). A referência é **derivada** por consulta, não armazenada:
+
+```sql
+WITH r AS (
+  SELECT preco_centavos, PERCENT_RANK() OVER (ORDER BY preco_centavos) AS pr
+  FROM precos_coletados
+  WHERE produto_id = :produto_id AND coletado_em >= datetime('now', '-90 days')
+)
+SELECT MAX(CASE WHEN pr <= 0.50 THEN preco_centavos END) AS mediana,
+       MAX(CASE WHEN pr <= 0.25 THEN preco_centavos END) AS p25
+FROM r
+```
+
+Com menos de 5 amostras em 90 dias, o CLI avisa explicitamente "referência fraca".
+
+### Uso
+
+```bash
+python -m precos.cli referencia --produto 1 --dias 90
+```
+
+### Verificação feita
+
+Testado com 6 observações de preço (599, 649, 629, 579, 899, 619 centavos): mediana = 619, p25 = 599, mínimo = 579 — os três valores batendo com o cálculo manual.
+
+---
+
+## Fase 4 — Matching com portão de unidade (F04) ⬜
+
+**Status:** especificado em detalhe no PRD v2, **não implementado**.
+
+### Problema que resolve
+
+O `fuzz.WRatio` da v1, sozinho, pontua alto entre "Leite Italac Integral 1L" e "Leite Italac Integral 200ml" — quase todos os tokens coincidem, e a diferença de quantidade é tratada como só mais um token. É o falso positivo citado no risco 2 da seção 6 do PRD v1.
+
+### Pipeline especificado (5 estágios)
+
+```
+título bruto
+  → 1. normalizar (minúsculas, sem acento, abreviações expandidas)
+  → 2. extrair marca + quantidade + unidade como CAMPOS
+  → 3. alias exato (produto_aliases) — decisão humana anterior, determinístico
+  → 4. EAN exato
+  → 5. fuzzy com blocking por marca + PORTÃO DE UNIDADE (regra dura, não peso)
+```
+
+Três faixas de decisão, não um corte único: aceite automático / fila de revisão manual / rejeição. Toda revisão manual confirmada vira alias permanente — o sistema fica mais preciso com o uso.
+
+**Já implementado e testado que a fase 4 vai consumir:** `extrair_do_titulo()` em `precos/normalize/quantidades.py` já separa quantidade do texto residual — é o dado que falta ao matcher da v1. O teste `test_quantidades.py::test_o_falso_positivo_do_prd` já prova a peça central: os títulos residuais de "Leite 1L" e "Leite 200ml" ficam idênticos, mas as quantidades extraídas ficam diferentes — é exatamente o par (texto igual, quantidade diferente) que o portão da fase 4 vai barrar.
+
+**Falta:** a lógica de blocking + fuzzy + as três faixas de decisão + leitura/escrita de `produto_aliases` e `matches`.
+
+Detalhamento completo: [`PRD_PRECOS_V2.md` §3](./PRD_PRECOS_V2.md#3-motor-de-pareamento-f04-revisado).
+
+---
+
+## Fase 5 — Calibração do threshold ⬜
+
+**Status:** especificado, não implementado. Depende da fase 4 existir.
+
+### Procedimento
+
+1. Rotular ~200 pares reais (match / não-match) à mão.
+2. Rodar a pipeline variando o limite, medir precisão e recall em cada ponto.
+3. Escolher `LIMITE_AUTO` pelo alvo de precisão — **≥ 98%** sugerido.
+
+Por quê: em alerta de compra, falso positivo custa muito mais que falso negativo. Perder uma oferta é chato; mandar o usuário comprar a coisa errada destrói a confiança no sistema. O 85 da v1 era um número escolhido sem medição.
+
+Detalhamento: [`PRD_PRECOS_V2.md` §3.3](./PRD_PRECOS_V2.md#33-como-calibrar-os-limites-não-chute).
+
+---
+
+## Fase 6 — Alertas (F05) ⬜
+
+**Status:** especificado, não implementado. **O F05 da v1 estava literalmente em branco** — título "Regra de Alerta:" sem regra abaixo.
+
+### Regra especificada (todas as condições precisam valer)
+
+| # | Condição | Motivo |
+|---|---|---|
+| 1 | `preco ≤ referencia × (1 − DESCONTO_MIN_PCT)` | desconto percentual mínimo |
+| 2 | `economia_centavos ≥ ECONOMIA_MIN_CENTAVOS` | evita alertar R$0,30 num item de R$3,00 |
+| 3 | `preco ≥ referencia × PISO_SANIDADE` | queda de 95% é erro de parsing, não oferta |
+| 4 | `match.status IN ('auto','confirmado')` | nunca alerta sobre pareamento não verificado |
+| 5 | sem alerta com o mesmo `alert_key` no cooldown | impede repetir a cada execução |
+| 6 | `oferta.disponivel = 1` | não alerta produto esgotado |
+
+Parâmetros iniciais sugeridos: desconto mínimo 15%, economia mínima R$2,00, piso de sanidade 30% (rejeita quedas >70%), cooldown 48h, teto de 10 alertas/dia.
+
+**Ponto de produto, não só de engenharia:** frete e pedido mínimo precisam entrar na conta — R$2,00 de economia com R$9,99 de entrega é prejuízo. Mínimo viável: declarar a taxa na mensagem do alerta.
+
+Detalhamento: [`PRD_PRECOS_V2.md` §4](./PRD_PRECOS_V2.md#4-motor-de-alertas-f05--a-regra-que-faltava).
+
+---
+
+## Fase 7 — Segundo varejista ⬜
+
+**Status:** não iniciado. Depende da fase 4 (para validar que a modelagem multi-fonte se sustenta).
+
+O coletor VTEX (fase 2) já foi escrito de forma genérica — `ColetorVtex` recebe uma `FonteVtex` como configuração (`precos/config.py`), então adicionar Pão de Açúcar (ou outro varejista VTEX) é, em princípio, configuração nova, não código novo. Isso ainda não foi testado contra um segundo host real.
+
+---
+
+## Fase 8 — iFood (F03) ⬜ — bloqueado por decisão, não por falta de tempo
+
+**Status:** não implementado. **Não será implementado via bypass de proteção antibot** — decisão registrada, não uma pendência técnica.
+
+### O que não será feito
+
+Estratégia de contorno de proteção de acesso do iFood: proxies residenciais rotativos, emulação de sessão, quebra de desafio de CDN. Independente da posição sobre isso, o argumento de engenharia também pesa: é uma dependência que se degrada sozinha, sem aviso, e sem correlação com o seu deploy.
+
+### Caminhos legítimos, em ordem de custo-benefício
+
+1. **Catálogo público VTEX dos varejistas** (fase 2/7) — já cobre boa parte do objetivo de comparação sem tocar no iFood.
+2. **Dados de preço originados de NFC-e via SEFAZ** (programa Menor Preço Brasil / Preço da Hora) — EAN, preço, estabelecimento e geolocalização, de nota fiscal real. **Ressalva importante:** não foi encontrada API pública documentada; o acesso divulgado é via portal/app, e bibliotecas de terceiro no GitHub consomem API privada — voltando ao mesmo problema do iFood. Encaminhamento correto é solicitar acesso institucional à SEFAZ/CONFAZ, não engenharia reversa.
+3. **Captura assistida pelo próprio usuário** logado, sem automação contra proteção.
+4. **Canal oficial de parceiro do iFood** — cobre catálogo próprio, não resolve comparação com concorrentes.
+
+Detalhamento completo: [`REVIEW_PRD_PRECOS.md` §5.1](./REVIEW_PRD_PRECOS.md#51-bloqueios-antibot-no-ifood).
+
+---
+
+## Fase 9 — Deploy web (Vercel) ⬜ — decisão em aberto
+
+**Status:** investigado, **decisão de stack pendente do usuário**.
+
+### O que já se sabe
+
+- O site em produção hoje (`dubairro.vercel.app`) está ligado a **outro repositório** (`thiagusantos-jpg/dubairro`, Python/FastAPI/Streamlit) — não a este (`mdb`). Zero erros de runtime nos últimos 7 dias; produção não recebe deploy desde março/2026 (10 deploys posteriores são previews de dependabot, nenhum mergeado).
+- A Vercel documenta oficialmente pool de conexão gerenciado para Postgres via `attachDatabasePool` (`@vercel/functions`) — **só para Node**, usando `pg.Pool`. Não há equivalente documentado para Python; lá a alternativa é abrir conexão manual via `psycopg2` contra a connection string do pooler do Supabase.
+- Este repositório já tem o padrão Node + `supabase-js` funcionando em produção (`lib/supabase.js`, `api/*.js`) — é o caminho de menor risco por já estar provado neste código-base.
+
+### As três opções levantadas (decisão não tomada)
+
+| Opção | Reaproveita os 95 testes Python? | Suporte nativo Vercel para pool de conexão | Risco |
+|---|---|---|---|
+| **Portar tudo para Node** | Não — vira referência de porte | Sim (`attachDatabasePool`) | Baixo (padrão já provado no repo) |
+| **Manter Python, deploy Python na Vercel** | Sim | Não — pool manual via `psycopg2` | Médio-alto (sem precedente no repo) |
+| **Híbrido** — coleta Python fora da Vercel (ex.: GitHub Actions) + API de leitura fina em Node na Vercel | Sim (coleta) | Sim (a parte que roda na Vercel é só leitura) | Baixo, mas coleta não roda "na Vercel" |
+
+A pergunta foi feita ao usuário e a resposta ficou pendente — retomar antes de iniciar a fase 9.
+
+---
+
+## 5. Estrutura de código atual
+
+```
+precos/
+├── __init__.py
+├── config.py                    parâmetros de coleta, alerta (futuro) e planilha
+├── cli.py                       migrar | importar | coletar | status | referencia
+├── servicos.py                  orquestração: liga coletores ao banco
+├── requirements.txt             requests (obrigatório); openpyxl (opcional, .xlsx)
+├── README.md                    guia de uso e decisões que divergem da v1
+├── exemplos/
+│   └── planilha_exemplo.csv
+├── storage/
+│   ├── schema.sql
+│   ├── db.py
+│   └── repositories.py
+├── normalize/
+│   ├── precos.py
+│   ├── quantidades.py
+│   └── texto.py
+├── collectors/
+│   ├── base.py                  contrato Coletor / OfertaBruta / ColetaAnomala
+│   ├── planilha.py
+│   └── vtex.py
+└── tests/                       95 testes, biblioteca padrão, sem rede
+    ├── test_precos.py
+    ├── test_quantidades.py
+    ├── test_texto.py
+    ├── test_planilha.py
+    ├── test_storage.py
+    └── test_vtex.py
+```
+
+## 6. Como rodar hoje
+
+```bash
+pip install -r precos/requirements.txt        # requests; openpyxl só para .xlsx
+
+python -m precos.cli migrar
+python -m precos.cli importar precos/exemplos/planilha_exemplo.csv
+python -m precos.cli coletar mambo --limite 200
+python -m precos.cli status
+python -m precos.cli referencia --produto 1 --dias 90
+
+python -m unittest discover -s precos -t .     # 95 testes
+```
+
+## 7. Configuração
+
+Tudo em `precos/config.py`, sobrescrevível por variável de ambiente — nenhum limiar ficará hardcoded no código quando as fases 4–6 forem implementadas:
+
+| Variável | Papel |
+|---|---|
+| `PRECOS_DB` | caminho do arquivo SQLite |
+| `PRECOS_USER_AGENT` | identificação honesta nas requisições — **configure antes de usar em rotina** |
+| `PRECOS_TIMEOUT_S`, `PRECOS_PAUSA_S` | timeout e pausa entre requisições ao coletor |
+| `PRECOS_MAX_TENTATIVAS`, `PRECOS_BACKOFF_BASE_S` | política de retry |
+| `PRECOS_MAMBO_URL` | host da loja VTEX (ver ressalva §8) |
+
+## 8. O que ainda não foi verificado contra o mundo real
+
+- **O host e o comportamento do endpoint VTEX não foram testados contra o Mambo real.** O ambiente onde este sistema foi escrito não tem saída de rede para esses domínios; os 30 testes da fase 2 usam sessão HTTP simulada. Antes de rodar em rotina: requisição manual de confirmação, leitura do `robots.txt` e dos Termos de Uso do varejista, `PRECOS_USER_AGENT` de verdade, volume baixo.
+- **A API pública de preços via NFC-e (SEFAZ) não está confirmada como existente/documentada** — tratar como "solicitar acesso institucional", não como integração pronta.
+
+## 9. Erros da v1 corrigidos — resumo rastreável
+
+| Defeito na v1 | Correção na v2 | Coberto por teste |
+|---|---|---|
+| `ean TEXT PRIMARY KEY` excluía produto sem código de barras | `id` surrogate + índice único parcial em `ean` | `test_storage.py::test_varios_produtos_sem_ean` |
+| `INSERT OR REPLACE` apagava o preço anterior | Tabela fato `precos_coletados`, append-only | `test_storage.py::test_historico_preserva_todas_as_observacoes` |
+| FK para produto inexistente descartava oferta nova, e nem era aplicada no SQLite | Oferta sempre gravada; FK realmente ligada via `PRAGMA` | `test_storage.py::test_fk_realmente_barra`, `test_oferta_sem_produto_conhecido_e_gravada` |
+| Sem quantidade/unidade — causa do falso positivo 200g×500g | Campos `quantidade`/`unidade` extraídos do título | `test_quantidades.py::test_o_falso_positivo_do_prd` |
+| `REAL` para dinheiro (erro de ponto flutuante) | Inteiro em centavos | `test_precos.py::test_precisao_de_centavos` |
+| Planilha: `row['Preco']` no código vs. `Preco_Referencia` na spec | Aceita as duas grafias de coluna | `test_planilha.py::test_coluna_preco_do_codigo_do_prd` |
+| Preço vazio virava `NaN` e sumia em silêncio | Descartado com motivo registrado | `test_planilha.py::test_preco_vazio_e_descartado_com_motivo` |
+| EAN corrompido pelo Excel (float, notação científica) | `normalizar_ean()` reconstrói o código | `test_texto.py::test_float_do_excel` |
+| Coleta zero itens em silêncio, parece "sem oferta hoje" | `ColetaAnomala` — falha alto abaixo do piso | `test_vtex.py::test_coleta_vazia_falha_alto` |
+| Seletor VTEX versionado quebra sem aviso | JSON público estruturado, sem depender de classe CSS | — (mudança de abordagem, não de correção pontual) |
+| `fuzz.WRatio` sozinho aceita 200g≈500g | Portão de unidade obrigatório (fase 4, especificado) | ⬜ pendente de implementação |
+| F05 sem regra de alerta | 6 condições explícitas + cooldown (fase 6, especificado) | ⬜ pendente de implementação |
+
+---
+
+**Documentos relacionados:** [`REVIEW_PRD_PRECOS.md`](./REVIEW_PRD_PRECOS.md) (crítica completa da v1) · [`PRD_PRECOS_V2.md`](./PRD_PRECOS_V2.md) (design detalhado, schema, pipelines) · [`precos/README.md`](../precos/README.md) (guia de uso do código)

--- a/docs/REVIEW_PRD_PRECOS.md
+++ b/docs/REVIEW_PRD_PRECOS.md
@@ -1,0 +1,360 @@
+# Revisão Técnica — PRD "Monitoramento e Comparação de Preços (iFood & Varejo)" v1.0
+
+**Documento revisado:** PRD v1.0 — Sistema de Monitoramento e Comparação de Preços de Supermercado
+**Premissa mantida:** Python 3.10+ / SQLite standalone, conforme decisão do autor
+**PRD corrigido:** [`PRD_PRECOS_V2.md`](./PRD_PRECOS_V2.md)
+
+---
+
+## Resumo executivo
+
+A ideia é boa e o problema é real: preço de mercearia varia diariamente e ninguém compara à mão.
+A arquitetura proposta é razoável em espírito — coletar, normalizar, parear, alertar — e as escolhas
+de stack são defensáveis.
+
+Mas o PRD tem **um bloqueio de origem** e **um defeito estrutural** que, sozinho, inviabiliza o
+objetivo declarado:
+
+1. **O bloqueio:** o item 1 da seção 6 pede estratégia de contorno da proteção antibot do iFood.
+   Não vou desenhar isso — detalhes e alternativas na seção 5 abaixo.
+2. **O defeito estrutural:** *o banco não guarda histórico de preços.* `produtos_base` tem uma única
+   coluna `preco_referencia`, sobrescrita a cada importação. Sem série temporal não existe "preço
+   médio", nem percentil, nem "menor preço dos últimos 90 dias" — e é exatamente isso que distingue
+   uma oferta real de um preço normal. O sistema como está descrito só sabe responder "está abaixo
+   da planilha que eu digitei", que é uma régua estática e envelhece em dias.
+
+O resto desta revisão detalha esses e outros pontos, em ordem de impacto.
+
+---
+
+## 1. Veredito por feature
+
+| Feature | Veredito | Razão em uma linha |
+|---------|----------|--------------------|
+| **F01** — Base de referência (planilha) | ✅ Viável | Simples; mas o código do PRD lê `row['Preco']` enquanto a spec define `Preco_Referencia`, e `.xlsx` é prometido e não implementado. |
+| **F02** — Extrator de varejo | ✅ Viável, com abordagem trocada | Mambo e Pão de Açúcar rodam VTEX: existe JSON público estruturado. Raspar DOM com seletores versionados é a pior das opções disponíveis. |
+| **F03** — Extrator do iFood | ⛔ Bloqueado | Depende de contornar proteção de acesso. Ver seção 5.1. |
+| **F04** — Motor de pareamento | ⚠️ Viável, mas inseguro como especificado | `WRatio` + corte em 85 casa "Leite 1L" com "Leite 200ml". Falta portão de unidade e curadoria. |
+| **F05** — Motor de alertas | ⚠️ Incompleto | **A regra de alerta está literalmente em branco no PRD** ("Regra de Alerta:" seguido de nada). |
+
+---
+
+## 2. Banco de dados — 9 defeitos no schema da seção 4
+
+### 2.1 `ean TEXT PRIMARY KEY` — chave errada
+
+Três problemas de uma vez:
+
+- **Exclui produtos sem EAN.** Hortifruti, açougue, padaria e granel não têm código de barras de
+  produto (têm PLU interno ou etiqueta de balança). Como `PRIMARY KEY` implica `NOT NULL`, esses
+  itens simplesmente não cabem na tabela — e são justamente onde a variação de preço é maior.
+- **Impede cadastrar antes de conhecer o EAN.** Você não pode registrar "quero monitorar arroz
+  Tio João 5kg" e descobrir o código depois.
+- **Amarra a identidade do produto ao código.** Quando o mesmo produto aparece com EAN da caixa
+  (DUN-14) em uma fonte e EAN da unidade (EAN-13) em outra, viram dois produtos distintos.
+
+**Correção:** `id INTEGER PRIMARY KEY` surrogate + índice único parcial em `ean`
+(`CREATE UNIQUE INDEX ... WHERE ean IS NOT NULL`), permitindo múltiplos produtos sem EAN.
+
+### 2.2 Sem histórico de preços — o defeito mais grave
+
+`importar_csv` usa `INSERT OR REPLACE`, que **descarta o preço anterior**. Consequências:
+
+- Impossível calcular preço médio, mediana ou percentil.
+- Impossível detectar o padrão "sobe 20% na terça e volta na quinta", que é como boa parte das
+  'promoções' de varejo funciona.
+- Impossível responder "esse é o menor preço do trimestre?", que é a pergunta que justifica comprar.
+- Impossível medir volatilidade por categoria — e sem isso não dá para calibrar a frequência de
+  coleta que o próprio item 4 da seção 6 pergunta.
+
+**Correção:** tabela fato append-only `precos_coletados (produto_id, loja_id, preco_centavos,
+coletado_em)`. A "referência" deixa de ser um campo digitado e passa a ser derivada: mediana ou p25
+móvel dos últimos N dias. A planilha do usuário vira *uma fonte a mais*, não a verdade absoluta.
+
+### 2.3 `ofertas_ifood` amarrada a uma única fonte
+
+O nome da tabela e a coluna `loja_nome TEXT` fixam a modelagem em um marketplace. Mas o próprio PRD
+já lista Mambo e Pão de Açúcar no F02 — ou seja, a v1 nasce precisando de uma segunda tabela quase
+idêntica, e toda query de comparação vira `UNION`.
+
+**Correção:** `fontes` (iFood, Mambo, planilha, …) + `lojas` (com `fonte_id`, endereço, lat/lon) +
+uma tabela de ofertas única com `loja_id`. `loja_nome TEXT` repetido em cada linha também é
+denormalização que garante grafias divergentes do mesmo estabelecimento.
+
+### 2.4 A foreign key `ean_identificado REFERENCES produtos_base(ean)` faz mal e não faz o que promete
+
+- **Faz mal:** impede gravar uma oferta cujo EAN ainda não está na base. O dado bruto coletado —
+  que custou uma requisição — é perdido justamente no caso mais interessante (produto novo).
+- **Não faz o que promete:** no SQLite, a checagem de FK é **desligada por padrão**. Sem
+  `PRAGMA foreign_keys = ON` em toda conexão, essa constraint é decorativa. O `db_manager.py` do
+  PRD não a liga.
+
+**Correção:** separar coleta de pareamento. A oferta bruta é imutável e sempre gravada; o vínculo
+vive em `matches (oferta_id, produto_id, score, metodo, status)`. Isso também permite **rodar o
+matcher de novo com algoritmo melhor, sobre dados já coletados**, sem re-raspar nada — o que é o
+maior ganho prático dessa mudança.
+
+### 2.5 Sem quantidade e unidade normalizadas
+
+Não existe campo para `quantidade`, `unidade` ou `preco_por_unidade`. Isso é a causa raiz do falso
+positivo 200g × 500g citado na própria seção 6 — não dá para resolver no matcher se o dado não
+existe no modelo. E sem `R$/kg` e `R$/L`, "mais barato" é uma comparação sem sentido entre embalagens
+diferentes.
+
+### 2.6 `REAL` para dinheiro
+
+`preco_referencia REAL`, `preco_promocional REAL`. Ponto flutuante binário não representa `0,10`
+exatamente; somas e comparações de igualdade acumulam erro, e `percentual_economia` calculado sobre
+isso produz valores como `19.999999999999996%`.
+
+**Correção:** inteiro em centavos (`preco_centavos INTEGER`), formatando só na apresentação.
+
+### 2.7 `historico_alertas` sem chave de deduplicação
+
+A tabela registra o que foi enviado, mas nada impede reenviar. Como a oferta continua ativa na
+próxima varredura, **o mesmo alerta dispara a cada execução**. Com coleta de hora em hora, um único
+produto em promoção de fim de semana gera algo como 48 mensagens no Telegram. O usuário silencia o
+bot no segundo dia e o produto morre aí.
+
+**Correção:** `alert_key TEXT UNIQUE` (hash de produto + loja + faixa de preço) e janela de cooldown
+consultada antes do envio.
+
+### 2.8 Zero índices
+
+Nenhum `CREATE INDEX` no schema. As consultas quentes são "ofertas coletadas na última execução",
+"histórico de um produto" e "já alertei isso?" — todas viram full scan conforme a tabela fato cresce
+(e ela cresce rápido: 10k SKUs × 4 coletas/dia = 14,6M linhas/ano).
+
+### 2.9 Sem tabela de execuções
+
+Não há como saber se a última varredura rodou, quantos itens trouxe ou por que falhou. Quando um
+seletor VTEX mudar, o sistema vai coletar zero produtos **em silêncio** e simplesmente parar de
+alertar — o modo de falha mais perigoso, porque parece "não teve oferta hoje".
+
+Vale notar que este repositório já resolve esse problema em `database/migrations/001_init.sql`, com
+a tabela `sync_logs` (status, `records_synced`, `error_message`, `started_at`/`completed_at`). É o
+mesmo padrão, e vale copiar.
+
+---
+
+## 3. Código — análise dos 3 módulos
+
+### 3.1 `db_manager.py`
+
+| Problema | Detalhe |
+|----------|---------|
+| **Spec × código divergem** | F01 define a coluna `Preco_Referencia`; o código lê `row['Preco']`. Um dos dois está errado — e como está, o import quebra com `KeyError` na planilha que a própria spec descreve. |
+| `iterrows()` + execute linha a linha | Lento e sem controle transacional por lote. `executemany` com uma lista de tuplas resolve. |
+| Sem validação de EAN | `str(row['EAN'])` aceita qualquer coisa. Excel converte EAN para float (`7891234567890.0`) e para notação científica em códigos longos — corrupção silenciosa. Falta normalizar (strip, zero-padding) e validar dígito verificador GTIN. |
+| Sem tratamento de `NaN` | Linha com preço vazio vira `float('nan')`, é gravada, e depois compara `False` em qualquer `<`, sumindo dos alertas sem erro. |
+| `.xlsx` prometido, não implementado | F01 diz `.csv` **ou** `.xlsx`; só há `pd.read_csv`. |
+| Sem `PRAGMA foreign_keys = ON` | Ver 2.4. |
+
+### 3.2 `scraper_mambo.py`
+
+| Problema | Detalhe |
+|----------|---------|
+| **Abordagem** | Mambo roda em VTEX (confirmado: a loja responde em `mambo.myvtex.com`). Existe JSON estruturado público em `/api/catalog_system/pub/products/search`, com EAN e preço. Raspar HTML renderizado é mais lento, mais frágil e traz menos dados que a alternativa. Ver 5.1. |
+| `wait_for_timeout(4000)` | Espera cega: desperdiça 4s quando carrega em 800ms e falha silenciosamente quando demora 5s. Usar `wait_for_selector` ou aguardar a resposta de rede. |
+| Seletores versionados | `vtex-product-summary-2-x-container` carrega a versão do componente no nome. Uma atualização do tema muda o número e o scraper passa a retornar `[]` — sem erro. Obrigatório: se a contagem cair a zero (ou abaixo de um piso), **falhar alto**, não gravar vazio. |
+| `productBrand` não é o nome | Essa classe VTEX corresponde à marca, não ao título completo do produto. O nome que alimenta o fuzzy matching sai truncado ou errado. |
+| Parsing de preço frágil | `.replace(".", "").replace(",", ".")` funciona em `R$ 1.234,56` e em `R$ 12,34`, mas quebra em variações com espaço não separável (`\xa0`), centavos em `<sup>` separado (padrão comum em temas VTEX) ou preço por peso ("R$ 9,90 /kg"). Precisa ser uma função única e testada. |
+| Sem paginação | Coleta só o primeiro lote da categoria. Um supermercado tem milhares de SKUs. |
+| Sem rate limiting / retry / User-Agent | Nenhum backoff, nenhum tratamento de erro de rede, nenhuma identificação. |
+
+### 3.3 `matcher.py`
+
+| Problema | Detalhe |
+|----------|---------|
+| **`WRatio` é quase cego à quantidade** | O núcleo do risco 2 da seção 6. "Leite Integral Italac 1L" × "Leite Integral Italac 200ml" compartilham quase todos os tokens; o score fica bem acima de 85. O algoritmo está funcionando corretamente — a especificação é que está errada ao confiar só nele. |
+| Threshold 85 sem medição | Número escolhido a priori. Sem um conjunto rotulado, não há como afirmar se produz 2% ou 30% de falso positivo. |
+| Acoplamento silencioso do índice | `resultado` traz o índice dentro de `self.nomes_base`, e o código indexa `self.base[index]`. Só funciona porque as duas listas são construídas na mesma ordem — qualquer filtro futuro em uma delas corrompe o pareamento **sem lançar exceção**. |
+| Sem *blocking* | `extractOne` compara contra a base inteira a cada consulta. Com 10k produtos × 10k ofertas são 100M comparações por execução. Filtrar candidatos por marca ou categoria antes reduz isso em ordens de grandeza. |
+| Nada é aprendido | Toda execução repete o mesmo fuzzy sobre os mesmos títulos. Uma decisão humana ("esse título é esse produto") deveria ser gravada e reutilizada para sempre. |
+| Descarta o score de saída | Retorna `None` para tudo abaixo do corte. Os casos na faixa 70–85 são os mais valiosos para revisão manual e são simplesmente jogados fora. |
+
+---
+
+## 4. Lacunas de produto (não estão no PRD, mas decidem se o sistema serve)
+
+- **A regra de alerta não existe.** O F05 tem o título "Regra de Alerta:" e nenhuma regra abaixo.
+  É o coração do produto e ficou em branco.
+- **Frete e pedido mínimo não entram na conta.** Um item R$ 2,00 mais barato no iFood com R$ 9,99 de
+  taxa de entrega não é economia — é prejuízo de R$ 7,99. Comparação honesta acontece no nível de
+  **cesta**, ou o alerta precisa dizer "vale se você já for pedir mais coisas".
+- **Nenhuma métrica de sucesso.** Sem alvo de precisão do matching e sem teto de alertas por dia,
+  não há como dizer se o sistema está funcionando. Fadiga de alerta mata este produto mais rápido
+  que scraper quebrado.
+- **Nenhuma checagem de sanidade de preço.** Queda de 95% quase nunca é oferta; quase sempre é erro
+  de parsing (pegou centavos como reais, ou o preço do item de 100g no lugar do de 1kg).
+
+---
+
+## 5. Respostas aos 4 riscos da seção 6
+
+### 5.1 Bloqueios antibot no iFood
+
+**Não vou desenhar estratégia de contorno de proteção de acesso** — proxies residenciais rotativos,
+emulação de sessão ou quebra de desafio de CDN. É o único ponto deste PRD em que não posso ajudar
+como pedido.
+
+Vale registrar também o argumento de engenharia, porque ele é independente do resto: uma coleta que
+depende de vencer uma proteção ativa é uma dependência que se degrada sozinha, sem aviso e sem
+correlação com o seu deploy. Você passa a manter um sistema cujo modo de falha é "parou de funcionar
+na madrugada de domingo e ninguém sabe por quê" — em cima do qual você quer construir decisão de
+compra.
+
+**As alternativas legítimas, em ordem de custo-benefício:**
+
+**a) Catálogo público VTEX dos varejistas — o caminho mais forte hoje**
+
+Mambo é VTEX (confirmado). Pão de Açúcar e boa parte do varejo alimentar brasileiro também. Lojas
+VTEX expõem um endpoint de busca público:
+
+```
+/api/catalog_system/pub/products/search?fq=alternateIds_Ean:7898526205947
+/api/catalog_system/pub/products/search?fq=C:/<id-categoria>/&_from=0&_to=49
+```
+
+Retorna JSON estruturado com produto, SKUs, EAN e ofertas por seller (preço, preço de lista,
+disponibilidade). É **mais estável, mais rápido e mais rico** que raspar DOM, e substitui boa parte
+do módulo F02.
+
+> ⚠️ **Confirmar antes de codar.** Não consegui alcançar esses hosts do ambiente onde esta revisão
+> foi escrita (egress restrito), então o formato acima vem da documentação da VTEX e não de uma
+> chamada real ao Mambo. Valide com uma requisição manual, confira `robots.txt` e os Termos de Uso
+> de cada varejista, use `_from`/`_to` respeitando o limite de paginação da plataforma, identifique-se
+> num `User-Agent` honesto e mantenha volume baixo.
+
+**b) Dados públicos de preço originados de NFC-e (SEFAZ / Menor Preço Brasil)**
+
+Existe um programa nacional — **Menor Preço Brasil**, do CONFAZ, com origem no Preço da Hora da
+SEFAZ-BA — que publica preços praticados extraídos de NFC-e e NF-e reais, com busca por descrição,
+marca ou **código de barras**, e ordenação por proximidade geográfica. Em conteúdo, é *exatamente*
+o dado que este projeto quer: EAN + preço + estabelecimento + geolocalização, resolvendo de uma vez
+os riscos 2 e 3 desta seção.
+
+> ⚠️ **Ressalva honesta, e ela é importante:** eu **não encontrei API pública documentada** para esse
+> programa. O acesso oficial divulgado é via portal web e aplicativo; as bibliotecas que circulam no
+> GitHub consomem a API *privada* do app. Usar essas bibliotecas te devolve ao mesmo problema do
+> iFood, com a agravante de ser dado público que você poderia obter formalmente.
+>
+> **Encaminhamento recomendado:** solicitar acesso institucional à SEFAZ do seu estado / ao CONFAZ,
+> invocando a Lei de Acesso à Informação e a política de dados abertos. É burocrático e leva semanas,
+> mas se sair, você recebe uma fonte oficial, estável, gratuita, com EAN e georreferenciada — o que
+> torna metade deste PRD desnecessária. Vale o e-mail antes de escrever qualquer scraper.
+
+**c) Captura assistida pelo próprio usuário**
+
+Você, logado e navegando normalmente, exportando seu histórico de pedidos ou o carrinho. Sem
+automação contra a proteção. Cobre pouco volume, mas é o caminho legítimo para dados que só existem
+na sua sessão.
+
+**d) Canal oficial do iFood (Portal do Parceiro / API de desenvolvedor)**
+
+Se você opera como parceiro, tem acesso programático ao **seu próprio** catálogo e pedidos. Sendo
+direto: **isso não resolve o objetivo do PRD**, que é comparar com preços de terceiros. É útil para
+o outro lado da moeda — monitorar sua própria competitividade — e não substitui (a) ou (b).
+
+### 5.2 Ausência de EAN no iFood — fuzzy matching é suficiente?
+
+**Não.** Não na forma especificada, e o exemplo dado na própria pergunta (200g × 500g) é a prova:
+`WRatio` pontua alto justamente aí, porque quase todos os tokens coincidem e a diferença está em um
+número que o algoritmo trata como mais um token.
+
+O que torna confiável é uma pipeline em camadas, com um portão que o fuzzy não pode atravessar:
+
+1. **Normalizar** — minúsculas, sem acentos, expandir abreviações (`int` → integral, `ref` →
+   refrigerante), remover ruído de marketing.
+2. **Extrair estrutura** — marca, quantidade e unidade viram *campos*, não texto. `"Leite Italac
+   Integral 1L"` → `{marca: italac, qtd: 1000, un: ml}`.
+3. **Alias exato** — consultar `produto_aliases`: se um humano já confirmou esse título uma vez, a
+   resposta é imediata e determinística. **É a camada mais valiosa**, porque converte esforço humano
+   em ativo permanente.
+4. **EAN exato** — quando disponível, encerra.
+5. **Fuzzy com blocking por marca — e portão obrigatório de unidade.** Só compara candidatos da mesma
+   marca; e **rejeita qualquer par cuja quantidade convertida não bata**, por mais alto que seja o
+   score textual. O portão é uma regra dura, não um peso.
+
+E o corte deixa de ser um número só: **três faixas** — aceite automático, fila de revisão manual,
+rejeição. Cada revisão manual vira um alias (camada 3) e nunca mais é revista.
+
+Sobre o 85: é chute até ser medido. Rotule ~200 pares à mão, meça precisão e recall, e escolha o
+corte pelo alvo de precisão. Em alerta de compra, falso positivo custa muito mais que falso negativo
+— perder uma oferta é chato, mandar o usuário comprar a coisa errada destrói a confiança no sistema.
+
+### 5.3 Dependência de geolocalização
+
+Sem desenhar fixação de sessão no iFood. Nas fontes recomendadas o problema é bem menor:
+
+- **VTEX:** o recorte é por loja / *sales channel* / política comercial — parâmetro documentado,
+  não sessão frágil. Você fixa a loja e o preço é determinístico.
+- **Dados de NFC-e:** latitude, longitude e raio são parâmetro de consulta por natureza.
+
+O que importa é a **modelagem**, e ela vale para qualquer fonte: preço nunca é um atributo do
+produto, é sempre um fato de `(produto, loja, momento)`. Modele `lojas` com coordenadas e endereço
+desde o primeiro dia. Um schema que trata preço como coluna de produto — como o da v1 — não tem
+conserto incremental quando a segunda região entra.
+
+### 5.4 Frequência de raspagem
+
+Não existe número único certo; existe uma estrutura em dois níveis:
+
+- **Watchlist quente** (dezenas a poucas centenas de SKUs que você realmente compra): checagem
+  frequente, poucas requisições, é aqui que ofertas-relâmpago são pegas.
+- **Varredura fria** (catálogo inteiro): uma vez por dia, em janela de baixo tráfego, para manter a
+  série histórica e descobrir produtos novos.
+
+Com, em todos os casos: orçamento explícito de requisições/dia por fonte, backoff exponencial em
+erro, `If-None-Match`/`If-Modified-Since` quando a fonte suportar, e jitter entre requisições.
+
+E a resposta honesta à pergunta "qual a frequência ideal": **você ainda não pode saber.** A
+frequência deve derivar da volatilidade medida por categoria — hortifruti muda em horas, mercearia
+seca muda em semanas. Isso só é mensurável depois que a tabela de histórico (2.2) existir e tiver
+algumas semanas de dados. Comece conservador, meça, ajuste.
+
+---
+
+## 6. Ordem sugerida de implementação
+
+O que dá para entregar sem depender de nada bloqueado, e em ordem de valor por esforço:
+
+1. **Schema corrigido + importador de planilha** (F01) — base para todo o resto.
+2. **Coletor VTEX** de um varejista, via JSON público (F02) — primeira fonte real de dados.
+3. **Histórico + preço de referência derivado** — a partir daqui o sistema tem memória.
+4. **Pipeline de matching com portão de unidade + tabela de aliases** (F04).
+5. **Conjunto rotulado e calibração do threshold** — antes de confiar em qualquer alerta.
+6. **Alertas com regra explícita, dedupe e cooldown** (F05).
+7. **Segundo varejista** — valida que a modelagem multi-fonte se sustenta.
+8. **iFood** — somente por (a)/(b)/(c)/(d) da seção 5.1, e depois de tudo acima.
+
+O ponto importante dessa ordem: os passos 1 a 7 entregam um comparador de preços de varejo
+funcional e defensável. O iFood deixa de ser pré-requisito e vira um incremento.
+
+---
+
+## 7. Sobre o stack
+
+Mantida a decisão de Python + SQLite standalone. Duas observações práticas, sem propor troca:
+
+- **SQLite aguenta o volume** desse projeto com folga por anos, desde que os índices da seção 2.8
+  existam e o modo WAL esteja ligado. Não é o gargalo.
+- **O ponto de atenção é durabilidade, não desempenho.** O banco vive em uma máquina só; a série
+  histórica é o ativo do projeto e leva meses para ser reconstruída, se é que pode. Backup
+  automatizado do arquivo `.db` para fora da máquina, desde o primeiro dia.
+
+---
+
+**Continua em:** [`PRD_PRECOS_V2.md`](./PRD_PRECOS_V2.md) — schema completo, pipeline de matching,
+regras de alerta e estrutura de módulos.
+
+## Fontes consultadas
+
+- [Catalog API — VTEX Developers](https://developers.vtex.com/docs/guides/catalog-api-overview)
+- [Legacy Search API — VTEX Developers](https://developers.vtex.com/docs/api-reference/search-api)
+- [Consult product search information — VTEX Developers](https://developers.vtex.com/docs/guides/consult-product-search-information)
+- [Supermercado Mambo migra para VTEX](https://vtex.com/pt-br/blog/historias-de-clientes/supermercado-mambo-migra-para-vtex/)
+- [CONFAZ — Aplicativo Menor Preço Brasil](https://www.confaz.fazenda.gov.br/noticias-do-confaz/confaz-lanca-aplicativo-menor-preco-brasil-destinado-a-ajudar-o-cidadao-a-encontrar-os-melhores-valores-no-comercio)
+- [Preço da Hora Bahia — Sobre](https://precodahora.ba.gov.br/sobre)
+- [SEFAZ-ES — Menor Preço](https://internet.sefaz.es.gov.br/informacoes/menorpreco/duvidas.php)
+- [Menor Preço — Nota Fiscal Gaúcha](https://nfg.sefaz.rs.gov.br/site/MenorPreco.aspx)

--- a/precos/README.md
+++ b/precos/README.md
@@ -1,0 +1,96 @@
+# Monitor de preços — fases 1 e 2
+
+Implementação do [PRD v2](../docs/PRD_PRECOS_V2.md). Cobre os dois primeiros
+passos do roadmap:
+
+| Fase | Entrega | Status |
+|------|---------|--------|
+| 1 | Schema + importador de planilha (F01) | ✅ |
+| 2 | Coletor VTEX via JSON público (F02) | ✅ |
+| 3 | Série histórica + referência derivada | ✅ (veio junto: a planilha já entra como observação) |
+| 4 | Matching com portão de unidade | ⬜ |
+| 5 | Calibração do threshold | ⬜ |
+| 6 | Alertas | ⬜ |
+
+## Instalação
+
+```bash
+pip install -r precos/requirements.txt      # requests; openpyxl só para .xlsx
+```
+
+O CSV é lido com a biblioteca padrão — sem nenhuma dependência.
+
+## Uso
+
+```bash
+python -m precos.cli migrar                                   # cria o banco
+python -m precos.cli importar precos/exemplos/planilha_exemplo.csv
+python -m precos.cli coletar mambo --limite 200
+python -m precos.cli status
+python -m precos.cli referencia --produto 1 --dias 90
+```
+
+O caminho do banco vem de `PRECOS_DB` (padrão: `sistema_precos.db`) ou de `--banco`.
+
+## Formato da planilha
+
+Obrigatórias: uma coluna de **nome** e uma de **preço**. As demais são opcionais.
+
+```csv
+EAN,Nome,Preco_Referencia,Marca,Categoria
+7891234567895,Leite Italac Integral 1L,5.99,Italac,Laticínios
+,Banana Prata kg,7.90,,Hortifruti
+```
+
+O nome da coluna de preço aceita `Preco_Referencia` **e** `Preco` — o PRD v1
+divergia de si mesmo nesse ponto, então as duas planilhas existem por aí.
+Cabeçalhos acentuados (`Código`, `Descrição`, `Valor`) também são reconhecidos.
+
+Linha com preço ilegível é **descartada com motivo registrado**, nunca gravada.
+
+## Decisões que divergem do PRD v1
+
+**Sem pandas.** `pd.read_csv` infere tipos, e é essa inferência que transforma
+o EAN `7891234567890` no float `7891234567890.0` e códigos longos em notação
+científica. O módulo `csv` lê tudo como texto, que é o que se quer aqui, e
+evita ~50 MB de dependência para ler alguns milhares de linhas. `normalizar_ean`
+ainda assim conserta os dois formatos, porque planilha vinda de Excel chega
+corrompida de qualquer jeito.
+
+**Sem Playwright/BeautifulSoup na fase 2.** Lojas VTEX expõem
+`/api/catalog_system/pub/products/search`, com produto, SKU, EAN e oferta por
+seller. Os seletores da v1 (`vtex-product-summary-2-x-container`) carregam a
+versão do componente no nome: uma atualização de tema muda o número e o scraper
+passa a devolver lista vazia sem erro.
+
+**O preço da planilha não é uma coluna sobrescrevível.** Ele entra na série
+histórica como mais uma observação, de uma fonte chamada `planilha`. A
+referência é derivada (mediana/p25 de 90 dias) — reimportar acumula histórico
+em vez de destruí-lo.
+
+## Health check
+
+Coleta abaixo de `piso_esperado` levanta `ColetaAnomala`, a execução é marcada
+como `failed` e o CLI sai com código 3. É deliberado: o modo de falha mais
+perigoso do sistema é coletar zero item em silêncio e parecer "não teve oferta
+hoje".
+
+## Antes de rodar contra um varejista
+
+O host padrão e o comportamento do endpoint **não foram verificados contra a
+loja real** — o ambiente onde isso foi escrito não tem saída de rede para esses
+domínios. Antes de usar em rotina:
+
+1. Confirme o endpoint com uma requisição manual.
+2. Leia o `robots.txt` e os Termos de Uso do varejista.
+3. Ajuste `PRECOS_USER_AGENT` para algo que identifique você de verdade.
+4. Mantenha `PRECOS_PAUSA_S` alto e o volume baixo.
+
+## Testes
+
+```bash
+python -m unittest discover -s precos -t .
+```
+
+95 testes, biblioteca padrão apenas, sem rede — o coletor recebe a sessão HTTP
+por injeção e os testes usam respostas fixas.

--- a/precos/__init__.py
+++ b/precos/__init__.py
@@ -1,0 +1,7 @@
+"""Sistema de monitoramento e comparação de preços.
+
+Implementação do PRD v2 (docs/PRD_PRECOS_V2.md).
+Fases 1 e 2 do roadmap: schema + importador de planilha + coletor VTEX.
+"""
+
+__version__ = "0.2.0"

--- a/precos/cli.py
+++ b/precos/cli.py
@@ -1,0 +1,170 @@
+"""Linha de comando.
+
+    python -m precos.cli migrar
+    python -m precos.cli importar planilha.csv
+    python -m precos.cli coletar mambo --limite 200
+    python -m precos.cli status
+    python -m precos.cli referencia --produto 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import config, servicos
+from .collectors.base import ColetaAnomala, ErroDeColeta
+from .collectors.planilha import ErroDePlanilha
+from .normalize.precos import formatar_brl
+from .storage import db
+from .storage import repositories as repo
+
+
+def _cmd_migrar(args: argparse.Namespace) -> int:
+    conn = db.conectar(args.banco)
+    try:
+        db.migrar(conn)
+        tabelas = [
+            linha["name"]
+            for linha in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+            )
+        ]
+        print(f"Banco pronto em {args.banco or config.DB_PATH}")
+        print(f"Tabelas: {', '.join(tabelas)}")
+    finally:
+        conn.close()
+    return 0
+
+
+def _cmd_importar(args: argparse.Namespace) -> int:
+    with db.sessao(args.banco) as conn:
+        try:
+            resultado = servicos.importar_planilha(conn, args.arquivo)
+        except ErroDePlanilha as erro:
+            print(f"erro: {erro}", file=sys.stderr)
+            return 2
+
+    print(f"Colunas detectadas: {resultado.colunas_detectadas}")
+    print(
+        f"Produtos: {resultado.produtos_novos} novos, "
+        f"{resultado.produtos_atualizados} atualizados"
+    )
+    print(f"Preços registrados no histórico: {resultado.precos_registrados}")
+
+    if resultado.ean_sem_digito_valido:
+        print(
+            f"aviso: {resultado.ean_sem_digito_valido} EAN(s) com dígito verificador "
+            "inválido — importados, mas confira a planilha"
+        )
+    if resultado.descartadas:
+        print(f"\n{len(resultado.descartadas)} linha(s) descartada(s):")
+        for numero, motivo in resultado.descartadas[:20]:
+            print(f"  linha {numero}: {motivo}")
+        if len(resultado.descartadas) > 20:
+            print(f"  ... e mais {len(resultado.descartadas) - 20}")
+    return 0
+
+
+def _cmd_coletar(args: argparse.Namespace) -> int:
+    with db.sessao(args.banco) as conn:
+        try:
+            resultado = servicos.coletar_vtex(conn, args.fonte, limite=args.limite)
+        except ColetaAnomala as erro:
+            # Falha alto de propósito: coletar quase nada é sintoma, não resultado.
+            print(f"COLETA ANÔMALA: {erro}", file=sys.stderr)
+            return 3
+        except ErroDeColeta as erro:
+            print(f"erro de coleta: {erro}", file=sys.stderr)
+            return 2
+        except ValueError as erro:
+            print(f"erro: {erro}", file=sys.stderr)
+            return 2
+
+    print(f"Fonte {resultado.fonte}: {resultado.ofertas} ofertas gravadas")
+    print(f"Com EAN: {resultado.com_ean} ({resultado.com_ean * 100 // max(resultado.ofertas, 1)}%)")
+    print(f"Execução #{resultado.execucao_id}")
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    with db.sessao(args.banco) as conn:
+        produtos = repo.contar_produtos(conn)
+        ofertas = repo.contar_ofertas(conn)
+        execucoes = repo.ultimas_execucoes(conn, args.limite)
+
+    print(f"Produtos na base: {produtos}")
+    print(f"Ofertas coletadas: {ofertas}\n")
+
+    if not execucoes:
+        print("Nenhuma execução registrada.")
+        return 0
+
+    print(f"{'#':>4}  {'FONTE':<12} {'TIPO':<10} {'STATUS':<10} {'ITENS':>6}  INÍCIO")
+    for linha in execucoes:
+        print(
+            f"{linha['id']:>4}  {(linha['fonte'] or '—'):<12} {linha['tipo']:<10} "
+            f"{linha['status']:<10} {linha['itens_coletados']:>6}  {linha['iniciada_em']}"
+        )
+        if linha["erro"]:
+            print(f"        erro: {linha['erro'][:160]}")
+    return 0
+
+
+def _cmd_referencia(args: argparse.Namespace) -> int:
+    with db.sessao(args.banco) as conn:
+        dados = repo.preco_referencia(conn, args.produto, dias=args.dias)
+
+    if not dados["amostras"]:
+        print(f"Produto {args.produto}: sem amostras nos últimos {args.dias} dias.")
+        return 1
+
+    print(f"Produto {args.produto} — últimos {args.dias} dias")
+    print(f"  amostras: {dados['amostras']}")
+    print(f"  mínimo:   {formatar_brl(dados['minimo'])}")
+    print(f"  mediana:  {formatar_brl(dados['mediana'])}")
+    print(f"  p25:      {formatar_brl(dados['p25'])}")
+    if dados["amostras"] < 5:
+        print("  aviso: menos de 5 amostras — referência fraca (PRD v2 §2.1)")
+    return 0
+
+
+def construir_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="precos", description="Monitor de preços de supermercado (fases 1 e 2)"
+    )
+    parser.add_argument("--banco", type=Path, default=None, help="caminho do arquivo SQLite")
+    sub = parser.add_subparsers(dest="comando", required=True)
+
+    sub.add_parser("migrar", help="cria/atualiza o schema").set_defaults(func=_cmd_migrar)
+
+    p_importar = sub.add_parser("importar", help="importa planilha de referência (.csv/.xlsx)")
+    p_importar.add_argument("arquivo", type=Path)
+    p_importar.set_defaults(func=_cmd_importar)
+
+    p_coletar = sub.add_parser("coletar", help="coleta o catálogo público de uma loja VTEX")
+    p_coletar.add_argument("fonte", choices=sorted(config.FONTES_VTEX) or None)
+    p_coletar.add_argument("--limite", type=int, default=None, help="máximo de ofertas")
+    p_coletar.set_defaults(func=_cmd_coletar)
+
+    p_status = sub.add_parser("status", help="últimas execuções e totais")
+    p_status.add_argument("--limite", type=int, default=10)
+    p_status.set_defaults(func=_cmd_status)
+
+    p_ref = sub.add_parser("referencia", help="preço de referência derivado do histórico")
+    p_ref.add_argument("--produto", type=int, required=True)
+    p_ref.add_argument("--dias", type=int, default=90)
+    p_ref.set_defaults(func=_cmd_referencia)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = construir_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/precos/collectors/__init__.py
+++ b/precos/collectors/__init__.py
@@ -1,0 +1,6 @@
+"""Coletores.
+
+Regra do PRD v2 (§5): coletor não escreve no banco. Ele devolve
+`list[OfertaBruta]` e quem persiste é o repositório — o que torna cada coletor
+testável sem banco e sem rede.
+"""

--- a/precos/collectors/base.py
+++ b/precos/collectors/base.py
@@ -1,0 +1,50 @@
+"""Contrato comum dos coletores."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+class ErroDeColeta(RuntimeError):
+    """Falha irrecuperável de coleta (rede, formato inesperado, bloqueio)."""
+
+
+class ColetaAnomala(ErroDeColeta):
+    """Coleta abaixo do piso esperado.
+
+    Existe como erro próprio porque o modo de falha mais perigoso do sistema é
+    coletar zero item em silêncio e parecer 'não teve oferta hoje'. Quando um
+    seletor ou um contrato de API muda, isso aqui precisa falhar alto.
+    """
+
+
+@dataclass(frozen=True)
+class OfertaBruta:
+    """Um item observado numa fonte, ainda sem pareamento com a base."""
+
+    titulo_original: str
+    preco_centavos: int
+    ean_informado: str | None = None
+    preco_de_centavos: int | None = None
+    disponivel: bool = True
+    url: str | None = None
+    marca: str | None = None
+    payload_bruto: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.titulo_original or not self.titulo_original.strip():
+            raise ValueError("oferta sem título")
+        if self.preco_centavos <= 0:
+            raise ValueError(f"preço inválido: {self.preco_centavos}")
+
+
+class Coletor(ABC):
+    """Interface comum. Uma implementação por fonte."""
+
+    slug: str
+
+    @abstractmethod
+    def coletar(self) -> list[OfertaBruta]:
+        """Devolve as ofertas observadas. Não toca no banco."""
+        raise NotImplementedError

--- a/precos/collectors/planilha.py
+++ b/precos/collectors/planilha.py
@@ -1,0 +1,200 @@
+"""F01 — importação da planilha de referência.
+
+Sobre não usar pandas, como o PRD v1 previa: `pd.read_csv` infere tipos, e é
+exatamente essa inferência que transforma o EAN 7891234567890 no float
+7891234567890.0 e códigos longos em notação científica — a corrupção silenciosa
+apontada na revisão (§3.1). O módulo `csv` da biblioteca padrão lê tudo como
+texto, que é o que se quer aqui, e evita uma dependência de ~50 MB para ler
+alguns milhares de linhas. `.xlsx` usa openpyxl, importado sob demanda.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+from .. import config
+from ..normalize.precos import parse_preco_brl
+from ..normalize.quantidades import extrair_do_titulo
+from ..normalize.texto import normalizar_ean, normalizar_titulo, validar_ean
+
+
+@dataclass
+class LinhaPlanilha:
+    numero: int
+    ean: str | None
+    nome: str
+    preco_centavos: int
+    marca: str | None = None
+    categoria: str | None = None
+    quantidade: float | None = None
+    unidade: str | None = None
+    ean_invalido: bool = False
+
+
+@dataclass
+class ResultadoLeitura:
+    linhas: list[LinhaPlanilha] = field(default_factory=list)
+    descartadas: list[tuple[int, str]] = field(default_factory=list)
+    ean_sem_digito_valido: int = 0
+    colunas_detectadas: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def total_lidas(self) -> int:
+        return len(self.linhas) + len(self.descartadas)
+
+
+class ErroDePlanilha(RuntimeError):
+    pass
+
+
+# --------------------------------------------------------------------------
+# Detecção de colunas
+# --------------------------------------------------------------------------
+
+
+def _chave(cabecalho: str) -> str:
+    return normalizar_titulo(cabecalho).replace(" ", "_")
+
+
+def _mapear_colunas(cabecalhos: list[str]) -> dict[str, str]:
+    """Liga nomes de coluna da planilha aos campos que usamos.
+
+    Aceita `Preco_Referencia` e `Preco`: o PRD v1 divergia de si mesmo nesse
+    ponto (a spec dizia um, o código lia o outro), então as duas planilhas
+    existem no mundo real.
+    """
+    normalizados = {_chave(c): c for c in cabecalhos if c}
+    mapa: dict[str, str] = {}
+
+    for campo, candidatos in (
+        ("ean", config.COLUNAS_EAN),
+        ("nome", config.COLUNAS_NOME),
+        ("preco", config.COLUNAS_PRECO),
+        ("marca", config.COLUNAS_MARCA),
+        ("categoria", config.COLUNAS_CATEGORIA),
+    ):
+        for candidato in candidatos:
+            if candidato in normalizados:
+                mapa[campo] = normalizados[candidato]
+                break
+
+    faltando = [c for c in ("nome", "preco") if c not in mapa]
+    if faltando:
+        raise ErroDePlanilha(
+            f"colunas obrigatórias ausentes: {', '.join(faltando)}. "
+            f"Cabeçalhos encontrados: {', '.join(cabecalhos)}"
+        )
+    return mapa
+
+
+# --------------------------------------------------------------------------
+# Leitura bruta
+# --------------------------------------------------------------------------
+
+
+def _ler_csv(caminho: Path) -> Iterator[dict[str, str]]:
+    # utf-8-sig descarta o BOM que o Excel escreve.
+    with caminho.open("r", encoding="utf-8-sig", newline="") as arquivo:
+        amostra = arquivo.read(8192)
+        arquivo.seek(0)
+        try:
+            dialeto = csv.Sniffer().sniff(amostra, delimiters=",;\t")
+        except csv.Error:
+            dialeto = csv.excel  # planilha de uma coluna só, ou amostra curta
+        yield from csv.DictReader(arquivo, dialect=dialeto)
+
+
+def _ler_xlsx(caminho: Path) -> Iterator[dict[str, str]]:
+    try:
+        from openpyxl import load_workbook
+    except ImportError as erro:  # pragma: no cover - depende do ambiente
+        raise ErroDePlanilha(
+            "leitura de .xlsx requer openpyxl: pip install openpyxl "
+            "(ou exporte a planilha como .csv)"
+        ) from erro
+
+    livro = load_workbook(filename=str(caminho), read_only=True, data_only=True)
+    try:
+        aba = livro.active
+        linhas = aba.iter_rows(values_only=True)
+        cabecalhos = [str(c) if c is not None else "" for c in next(linhas, ())]
+        for valores in linhas:
+            yield {
+                cabecalho: valor
+                for cabecalho, valor in zip(cabecalhos, valores)
+                if cabecalho
+            }
+    finally:
+        livro.close()
+
+
+def ler_planilha(caminho: Path | str) -> ResultadoLeitura:
+    """Lê e valida a planilha, sem tocar no banco.
+
+    Linha inválida é descartada COM motivo registrado, nunca gravada como NaN.
+    Na v1, um preço vazio virava float('nan'), era gravado, e depois sumia dos
+    alertas comparando False em qualquer '<' — sem erro nenhum.
+    """
+    origem = Path(caminho)
+    if not origem.exists():
+        raise ErroDePlanilha(f"arquivo não encontrado: {origem}")
+
+    sufixo = origem.suffix.lower()
+    if sufixo in (".csv", ".txt", ".tsv"):
+        registros = _ler_csv(origem)
+    elif sufixo in (".xlsx", ".xlsm"):
+        registros = _ler_xlsx(origem)
+    else:
+        raise ErroDePlanilha(f"formato não suportado: {sufixo} (use .csv ou .xlsx)")
+
+    resultado = ResultadoLeitura()
+    mapa: dict[str, str] | None = None
+
+    for indice, bruto in enumerate(registros, start=2):  # linha 1 = cabeçalho
+        if mapa is None:
+            mapa = _mapear_colunas(list(bruto.keys()))
+            resultado.colunas_detectadas = mapa
+
+        nome = str(bruto.get(mapa["nome"]) or "").strip()
+        if not nome:
+            resultado.descartadas.append((indice, "nome vazio"))
+            continue
+
+        preco = parse_preco_brl(bruto.get(mapa["preco"]))
+        if preco is None:
+            resultado.descartadas.append(
+                (indice, f"preço ilegível: {bruto.get(mapa['preco'])!r}")
+            )
+            continue
+        if preco <= 0:
+            resultado.descartadas.append((indice, f"preço não positivo: {preco}"))
+            continue
+
+        ean = normalizar_ean(bruto.get(mapa["ean"])) if "ean" in mapa else None
+        ean_invalido = bool(ean) and not validar_ean(ean)
+        if ean_invalido:
+            resultado.ean_sem_digito_valido += 1
+
+        quantidade, unidade, _ = extrair_do_titulo(nome)
+
+        resultado.linhas.append(
+            LinhaPlanilha(
+                numero=indice,
+                ean=ean,
+                nome=nome,
+                preco_centavos=preco,
+                marca=(str(bruto.get(mapa["marca"])).strip() if "marca" in mapa and bruto.get(mapa["marca"]) else None),
+                categoria=(str(bruto.get(mapa["categoria"])).strip() if "categoria" in mapa and bruto.get(mapa["categoria"]) else None),
+                quantidade=quantidade,
+                unidade=unidade,
+                ean_invalido=ean_invalido,
+            )
+        )
+
+    if mapa is None:
+        raise ErroDePlanilha("planilha vazia (nenhuma linha de dados)")
+
+    return resultado

--- a/precos/collectors/vtex.py
+++ b/precos/collectors/vtex.py
@@ -1,0 +1,256 @@
+"""F02 — coletor de lojas VTEX via catálogo público.
+
+Por que JSON e não DOM: os seletores do PRD v1
+(`vtex-product-summary-2-x-container`) carregam a versão do componente no nome.
+Uma atualização de tema muda o número e o scraper passa a devolver lista vazia
+sem erro. O endpoint de busca pública devolve produto, SKU, EAN e oferta por
+seller — mais estável, mais rápido e mais rico.
+
+    GET /api/catalog_system/pub/products/search?_from=0&_to=49
+    GET /api/catalog_system/pub/products/search?fq=C:/<id-categoria>/
+    GET /api/catalog_system/pub/products/search?fq=alternateIds_Ean:<ean>
+
+Cuidados que fazem parte de usar um endpoint público de terceiro: volume baixo,
+pausa entre requisições, backoff em erro e User-Agent honesto. Leia o
+robots.txt e os Termos de Uso do varejista antes de rodar isso em rotina.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Protocol
+from urllib.parse import urljoin
+
+from .. import config
+from ..normalize.precos import parse_preco_brl
+from ..normalize.texto import normalizar_ean
+from .base import ColetaAnomala, Coletor, ErroDeColeta, OfertaBruta
+
+CAMINHO_BUSCA = "/api/catalog_system/pub/products/search"
+
+
+class Resposta(Protocol):  # pragma: no cover - contrato
+    status_code: int
+    text: str
+
+    def json(self) -> Any: ...
+
+
+class Sessao(Protocol):  # pragma: no cover - contrato
+    def get(self, url: str, **kwargs: Any) -> Resposta: ...
+
+
+def _sessao_padrao() -> Sessao:
+    import requests  # importado aqui para o pacote não exigir rede em testes
+
+    sessao = requests.Session()
+    sessao.headers.update({"User-Agent": config.USER_AGENT, "Accept": "application/json"})
+    return sessao
+
+
+class ColetorVtex(Coletor):
+    """Varre o catálogo público de uma loja VTEX."""
+
+    def __init__(
+        self,
+        fonte: config.FonteVtex,
+        *,
+        sessao: Sessao | None = None,
+        limite: int | None = None,
+        pausa_s: float | None = None,
+        dormir=time.sleep,
+    ) -> None:
+        self.fonte = fonte
+        self.slug = fonte.slug
+        self._sessao = sessao
+        self.limite = limite
+        self.pausa_s = config.PAUSA_ENTRE_REQUISICOES_S if pausa_s is None else pausa_s
+        self._dormir = dormir
+
+    # -- HTTP ------------------------------------------------------------
+
+    @property
+    def sessao(self) -> Sessao:
+        if self._sessao is None:
+            self._sessao = _sessao_padrao()
+        return self._sessao
+
+    def _buscar(self, params: dict[str, Any]) -> list[dict]:
+        url = urljoin(self.fonte.base_url, CAMINHO_BUSCA)
+        ultimo_erro = ""
+
+        for tentativa in range(1, config.MAX_TENTATIVAS + 1):
+            try:
+                resposta = self.sessao.get(
+                    url,
+                    params=params,
+                    headers={"User-Agent": config.USER_AGENT, "Accept": "application/json"},
+                    timeout=config.TIMEOUT_S,
+                )
+            except Exception as erro:  # rede instável
+                ultimo_erro = f"{type(erro).__name__}: {erro}"
+                self._recuar(tentativa)
+                continue
+
+            # 206 Partial Content é a resposta normal de busca paginada na VTEX.
+            if resposta.status_code in (200, 206):
+                try:
+                    dados = resposta.json()
+                except (ValueError, json.JSONDecodeError) as erro:
+                    raise ErroDeColeta(f"resposta não-JSON de {url}: {erro}") from erro
+                if not isinstance(dados, list):
+                    raise ErroDeColeta(f"formato inesperado em {url}: {type(dados).__name__}")
+                return dados
+
+            if resposta.status_code == 429 or resposta.status_code >= 500:
+                ultimo_erro = f"HTTP {resposta.status_code}"
+                self._recuar(tentativa)
+                continue
+
+            # 4xx que não seja 429 não melhora com repetição.
+            raise ErroDeColeta(
+                f"HTTP {resposta.status_code} em {url} (params={params}). "
+                "Confirme o host e se a loja expõe o catálogo público."
+            )
+
+        raise ErroDeColeta(f"falhou após {config.MAX_TENTATIVAS} tentativas: {ultimo_erro}")
+
+    def _recuar(self, tentativa: int) -> None:
+        if tentativa < config.MAX_TENTATIVAS:
+            self._dormir(config.BACKOFF_BASE_S ** tentativa)
+
+    # -- Coleta ----------------------------------------------------------
+
+    def coletar(self) -> list[OfertaBruta]:
+        ofertas: list[OfertaBruta] = []
+        vistos: set[str] = set()
+
+        consultas: list[dict[str, Any]] = (
+            [{"fq": f"C:/{c}/"} for c in self.fonte.categorias]
+            if self.fonte.categorias
+            else [{}]
+        )
+
+        for base_params in consultas:
+            ofertas.extend(self._varrer(base_params, vistos, restante=self._restante(ofertas)))
+            if self._atingiu_limite(ofertas):
+                break
+
+        if len(ofertas) < self.fonte.piso_esperado:
+            raise ColetaAnomala(
+                f"coleta anômala em '{self.slug}': {len(ofertas)} itens, "
+                f"piso esperado {self.fonte.piso_esperado}. "
+                "Provável mudança de contrato da API ou bloqueio — não é 'não teve produto hoje'."
+            )
+
+        return ofertas
+
+    def _restante(self, ofertas: list[OfertaBruta]) -> int | None:
+        return None if self.limite is None else max(0, self.limite - len(ofertas))
+
+    def _atingiu_limite(self, ofertas: list[OfertaBruta]) -> bool:
+        return self.limite is not None and len(ofertas) >= self.limite
+
+    def _varrer(
+        self, base_params: dict[str, Any], vistos: set[str], restante: int | None
+    ) -> list[OfertaBruta]:
+        coletadas: list[OfertaBruta] = []
+        inicio = 0
+        passo = config.VTEX_TAMANHO_PAGINA
+
+        while restante is None or len(coletadas) < restante:
+            if inicio > config.VTEX_OFFSET_MAXIMO:
+                # A plataforma recusa deslocamentos grandes. Para varrer um
+                # catálogo inteiro, fatie por categoria em vez de paginar sem fim.
+                break
+
+            params = dict(base_params)
+            params["_from"] = inicio
+            params["_to"] = inicio + passo - 1  # janela inclusiva
+
+            pagina = self._buscar(params)
+            if not pagina:
+                break
+
+            for produto in pagina:
+                for oferta in self._extrair(produto):
+                    chave = f"{oferta.ean_informado or ''}|{oferta.titulo_original}|{oferta.url or ''}"
+                    if chave in vistos:
+                        continue
+                    vistos.add(chave)
+                    coletadas.append(oferta)
+                    if restante is not None and len(coletadas) >= restante:
+                        return coletadas
+
+            if len(pagina) < passo:
+                break  # última página
+
+            inicio += passo
+            if self.pausa_s:
+                self._dormir(self.pausa_s)
+
+        return coletadas
+
+    # -- Extração --------------------------------------------------------
+
+    def _extrair(self, produto: dict) -> list[OfertaBruta]:
+        """Um produto VTEX vira uma oferta por SKU disponível.
+
+        SKUs distintos do mesmo produto são embalagens distintas (500g e 1kg
+        convivem sob o mesmo productId) e precisam virar linhas separadas —
+        colapsar aqui reintroduziria a confusão de gramatura pelo outro lado.
+        """
+        titulo_base = (produto.get("productName") or "").strip()
+        marca = (produto.get("brand") or "").strip() or None
+        link = produto.get("link") or None
+
+        ofertas: list[OfertaBruta] = []
+        for item in produto.get("items") or []:
+            titulo = (item.get("name") or titulo_base).strip() or titulo_base
+            if not titulo:
+                continue
+
+            ean = normalizar_ean(item.get("ean"))
+
+            for vendedor in item.get("sellers") or []:
+                comercial = vendedor.get("commertialOffer") or {}
+
+                preco = parse_preco_brl(comercial.get("Price"))
+                if preco is None or preco <= 0:
+                    continue
+
+                de = parse_preco_brl(comercial.get("ListPrice"))
+                if de is not None and de <= preco:
+                    de = None  # "de/por" sem desconto real não é preço-de
+
+                disponivel = bool(
+                    comercial.get("IsAvailable", (comercial.get("AvailableQuantity") or 0) > 0)
+                )
+
+                ofertas.append(
+                    OfertaBruta(
+                        titulo_original=titulo,
+                        preco_centavos=preco,
+                        ean_informado=ean,
+                        preco_de_centavos=de,
+                        disponivel=disponivel,
+                        url=link,
+                        marca=marca,
+                        payload_bruto=json.dumps(
+                            {
+                                "productId": produto.get("productId"),
+                                "itemId": item.get("itemId"),
+                                "sellerId": vendedor.get("sellerId"),
+                                "commertialOffer": {
+                                    k: comercial.get(k)
+                                    for k in ("Price", "ListPrice", "AvailableQuantity", "IsAvailable")
+                                },
+                            },
+                            ensure_ascii=False,
+                        ),
+                    )
+                )
+                break  # basta o seller principal
+
+        return ofertas

--- a/precos/config.py
+++ b/precos/config.py
@@ -1,0 +1,85 @@
+"""Parâmetros do sistema.
+
+Regra do PRD v2 (§5): nenhum limiar hardcoded pelo código. Tudo vive aqui e é
+sobrescrevível por variável de ambiente, porque a calibração da fase 5 vai
+mudar esses números.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Banco
+# --------------------------------------------------------------------------
+
+DB_PATH = Path(os.environ.get("PRECOS_DB", "sistema_precos.db"))
+
+
+# --------------------------------------------------------------------------
+# Coleta
+# --------------------------------------------------------------------------
+
+# Identificação honesta. Não se passe por navegador.
+USER_AGENT = os.environ.get(
+    "PRECOS_USER_AGENT",
+    "monitor-precos/0.2 (uso pessoal; contato: configure PRECOS_USER_AGENT)",
+)
+
+TIMEOUT_S = float(os.environ.get("PRECOS_TIMEOUT_S", "20"))
+
+# Pausa entre requisições. Volume baixo é parte do trato de usar um endpoint
+# público: não transforme a coleta em carga para o varejista.
+PAUSA_ENTRE_REQUISICOES_S = float(os.environ.get("PRECOS_PAUSA_S", "1.0"))
+
+MAX_TENTATIVAS = int(os.environ.get("PRECOS_MAX_TENTATIVAS", "4"))
+BACKOFF_BASE_S = float(os.environ.get("PRECOS_BACKOFF_BASE_S", "2.0"))
+
+# A busca pública da VTEX devolve no máximo 50 itens por requisição
+# (janela _from.._to inclusiva) e recusa deslocamentos muito grandes.
+VTEX_TAMANHO_PAGINA = 50
+VTEX_OFFSET_MAXIMO = 2500
+
+
+@dataclass(frozen=True)
+class FonteVtex:
+    """Uma loja VTEX monitorada."""
+
+    slug: str
+    nome: str
+    base_url: str
+    nome_loja: str
+    codigo_loja: str = "principal"
+    # Health check (§5.1 do PRD): abaixo disso a coleta é tratada como falha,
+    # não como "não teve produto hoje".
+    piso_esperado: int = 20
+    # Categorias a varrer (fq=C:/<id>/). Vazio = busca geral.
+    categorias: tuple[str, ...] = field(default_factory=tuple)
+
+
+# Mambo roda em VTEX — confirmado na revisão (docs/REVIEW_PRD_PRECOS.md §5.1).
+# Confirme o host e o comportamento do endpoint com uma requisição manual antes
+# de rodar em volume, e leia o robots.txt e os Termos de Uso do varejista.
+FONTES_VTEX: dict[str, FonteVtex] = {
+    "mambo": FonteVtex(
+        slug="mambo",
+        nome="Mambo Supermercados",
+        base_url=os.environ.get("PRECOS_MAMBO_URL", "https://www.mambo.com.br"),
+        nome_loja="Mambo (loja online)",
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Importação de planilha
+# --------------------------------------------------------------------------
+
+# O PRD v1 divergia de si mesmo: a spec do F01 definia "Preco_Referencia" e o
+# código lia "Preco". Aceitamos os dois, além das variações óbvias.
+COLUNAS_EAN = ("ean", "codigo_barras", "gtin", "codigo")
+COLUNAS_NOME = ("nome", "produto", "descricao", "titulo")
+COLUNAS_PRECO = ("preco_referencia", "preco", "valor", "preco_venda")
+COLUNAS_MARCA = ("marca", "fabricante")
+COLUNAS_CATEGORIA = ("categoria", "secao", "departamento")

--- a/precos/exemplos/planilha_exemplo.csv
+++ b/precos/exemplos/planilha_exemplo.csv
@@ -1,0 +1,8 @@
+EAN,Nome,Preco_Referencia,Marca,Categoria
+7891234567895,Leite Italac Integral 1L,5.99,Italac,Laticínios
+7891000315507,Nescau Achocolatado 2x400g,"R$ 18,90",Nestlé,Mercearia
+7896004004013,Arroz Tio João Tipo 1 5kg,"R$ 24,90",Tio João,Mercearia
+,Banana Prata kg,7.90,,Hortifruti
+,Tomate Italiano kg,9.49,,Hortifruti
+7891910000197,Açúcar União Refinado 1kg,4.29,União,Mercearia
+7894900011517,Coca-Cola 2L,,Coca-Cola,Bebidas

--- a/precos/normalize/__init__.py
+++ b/precos/normalize/__init__.py
@@ -1,0 +1,5 @@
+"""Normalização de dados brutos das fontes.
+
+Regra do PRD v2 (§5): parsing mora em um lugar só. Todo coletor usa estas
+funções — nenhum deles reimplementa parsing de preço ou de quantidade.
+"""

--- a/precos/normalize/precos.py
+++ b/precos/normalize/precos.py
@@ -1,0 +1,117 @@
+"""Parsing e formatação de preços em Real.
+
+Dinheiro trafega e é gravado em CENTAVOS (inteiro). Float para dinheiro foi um
+dos defeitos apontados na revisão do PRD v1: 0,10 não tem representação binária
+exata e o erro se acumula em agregações.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation
+
+# Espaços que aparecem em HTML de e-commerce e quebram um split ingênuo.
+_ESPACOS_ESPECIAIS = dict.fromkeys(map(ord, "    ​"), " ")
+
+# Alguns temas VTEX renderizam os centavos em um elemento separado:
+# "R$ 12<sup>90</sup>". O texto extraído do DOM vira "R$ 1290" se você só
+# arrancar as tags — um erro de 100x, silencioso.
+_CENTAVOS_SUP = re.compile(
+    # Os centavos podem estar em outro elemento, e o elemento dos reais pode
+    # fechar antes: "R$ 12<sup>90</sup>" e "<span>R$ 5</span><sup>,49</sup>".
+    r"(\d[\d.,]*)\s*(?:<\s*/\s*[a-z]+\s*>\s*)*"
+    r"<\s*(sup|small|span)[^>]*>\s*,?\s*(\d{2})\s*<\s*/\s*\2\s*>",
+    re.IGNORECASE,
+)
+_TAGS = re.compile(r"<[^>]+>")
+
+# Sufixo de preço por medida: "R$ 9,90 /kg", "R$ 4,50 a unidade"
+_SUFIXO_MEDIDA = re.compile(
+    r"\s*(?:/|por\s+|a\s+)\s*(kg|quilo|g|l|litro|ml|un|und|unid|unidade)\.?\s*$",
+    re.IGNORECASE,
+)
+
+_NUMERO = re.compile(r"\d[\d.,]*")
+
+
+def parse_preco_brl(valor: object) -> int | None:
+    """Converte um preço em centavos.
+
+    Aceita número (interpretado como reais, que é o formato dos JSONs de API)
+    ou texto em português. Devolve None quando não há preço reconhecível —
+    nunca zero por engano, e nunca NaN.
+
+        >>> parse_preco_brl("R$ 1.234,56")
+        123456
+        >>> parse_preco_brl("R$ 12,34")
+        1234
+        >>> parse_preco_brl(12.9)
+        1290
+    """
+    if valor is None:
+        return None
+
+    # Números: já vêm em reais (VTEX devolve Price: 12.9).
+    if isinstance(valor, bool):
+        return None
+    if isinstance(valor, (int, float, Decimal)):
+        if isinstance(valor, float) and valor != valor:  # NaN
+            return None
+        try:
+            return int((Decimal(str(valor)) * 100).quantize(Decimal("1")))
+        except (InvalidOperation, OverflowError, ValueError):
+            return None
+
+    texto = str(valor).translate(_ESPACOS_ESPECIAIS).strip()
+    if not texto:
+        return None
+
+    # Centavos em elemento separado, antes de qualquer limpeza de tags.
+    casado = _CENTAVOS_SUP.search(texto)
+    if casado:
+        reais = casado.group(1).replace(".", "").replace(",", "")
+        return int(reais) * 100 + int(casado.group(3))
+
+    texto = _TAGS.sub(" ", texto)
+    texto = _SUFIXO_MEDIDA.sub("", texto.strip())
+
+    encontrado = _NUMERO.search(texto)
+    if not encontrado:
+        return None
+
+    numero = encontrado.group(0).rstrip(".,")
+    if not numero:
+        return None
+
+    tem_virgula = "," in numero
+    tem_ponto = "." in numero
+
+    if tem_virgula and tem_ponto:
+        # O separador decimal é o que aparece por último: "1.234,56" ou "1,234.56"
+        if numero.rfind(",") > numero.rfind("."):
+            numero = numero.replace(".", "").replace(",", ".")
+        else:
+            numero = numero.replace(",", "")
+    elif tem_virgula:
+        # Em pt-BR a vírgula é sempre decimal.
+        numero = numero.replace(",", ".", 1).replace(",", "")
+    elif tem_ponto:
+        casas = len(numero.split(".")[-1])
+        if numero.count(".") == 1 and casas in (1, 2):
+            pass  # "12.90" / "1.5" — ponto decimal, formato de API
+        else:
+            numero = numero.replace(".", "")  # "1.234" / "1.234.567" — milhar
+
+    try:
+        return int((Decimal(numero) * 100).quantize(Decimal("1")))
+    except (InvalidOperation, OverflowError, ValueError):
+        return None
+
+
+def formatar_brl(centavos: int | None) -> str:
+    """1234 -> 'R$ 12,34'. Só para apresentação."""
+    if centavos is None:
+        return "—"
+    sinal = "-" if centavos < 0 else ""
+    inteiro, resto = divmod(abs(centavos), 100)
+    return f"{sinal}R$ {inteiro:,.0f}".replace(",", ".") + f",{resto:02d}"

--- a/precos/normalize/quantidades.py
+++ b/precos/normalize/quantidades.py
@@ -1,0 +1,143 @@
+"""Extração e normalização de quantidade/unidade.
+
+É o dado que faltava no PRD v1 e a causa raiz do falso positivo 200g × 500g:
+sem quantidade como campo, o matcher não tem como recusar o par, por mais alto
+que seja o score textual.
+
+Unidades base: 'g' (massa), 'ml' (volume), 'un' (contagem).
+"""
+
+from __future__ import annotations
+
+import re
+
+# fator de conversão para a unidade base
+_UNIDADES = {
+    "kg": (1000.0, "g"),
+    "quilo": (1000.0, "g"),
+    "quilos": (1000.0, "g"),
+    "k": (1000.0, "g"),
+    "g": (1.0, "g"),
+    "gr": (1.0, "g"),
+    "grama": (1.0, "g"),
+    "gramas": (1.0, "g"),
+    "mg": (0.001, "g"),
+    "l": (1000.0, "ml"),
+    "lt": (1000.0, "ml"),
+    "lts": (1000.0, "ml"),
+    "litro": (1000.0, "ml"),
+    "litros": (1000.0, "ml"),
+    "ml": (1.0, "ml"),
+    "un": (1.0, "un"),
+    "und": (1.0, "un"),
+    "unid": (1.0, "un"),
+    "unidade": (1.0, "un"),
+    "unidades": (1.0, "un"),
+    "dz": (12.0, "un"),
+    "duzia": (12.0, "un"),
+    "dúzia": (12.0, "un"),
+}
+
+_ALTERNATIVAS = "|".join(sorted(_UNIDADES, key=len, reverse=True))
+
+# "2x500ml", "2 x 500 ml", "6x1L"
+_MULTIPLO = re.compile(
+    rf"(?<![\w,.])(\d+)\s*[x×]\s*(\d+(?:[.,]\d+)?)\s*({_ALTERNATIVAS})(?![a-zA-Z])",
+    re.IGNORECASE,
+)
+# "1L", "200 g", "1,5 L"
+_SIMPLES = re.compile(
+    rf"(?<![\w,.])(\d+(?:[.,]\d+)?)\s*({_ALTERNATIVAS})(?![a-zA-Z])",
+    re.IGNORECASE,
+)
+# "kg" sozinho: produto vendido a peso ("Banana Prata kg") -> 1 kg
+_NUA = re.compile(rf"(?<![\w])({_ALTERNATIVAS})(?![a-zA-Z])", re.IGNORECASE)
+
+
+def _para_float(texto: str) -> float:
+    return float(texto.replace(".", "").replace(",", ".")) if "," in texto else float(texto)
+
+
+def parse_quantidade(texto: str | None) -> tuple[float, str] | None:
+    """Converte uma expressão de quantidade para (valor, unidade base).
+
+        >>> parse_quantidade("1L")
+        (1000.0, 'ml')
+        >>> parse_quantidade("2x500ml")
+        (1000.0, 'ml')
+        >>> parse_quantidade("kg")
+        (1000.0, 'g')
+
+    O multiplicador é resolvido no total ('2x500ml' = 1000ml), que é o que
+    permite comparar preço por litro entre embalagens diferentes.
+    """
+    if not texto:
+        return None
+    alvo = str(texto).strip()
+    if not alvo:
+        return None
+
+    casado = _MULTIPLO.search(alvo)
+    if casado:
+        fator, base = _UNIDADES[casado.group(3).lower()]
+        return int(casado.group(1)) * _para_float(casado.group(2)) * fator, base
+
+    casado = _SIMPLES.search(alvo)
+    if casado:
+        fator, base = _UNIDADES[casado.group(2).lower()]
+        return _para_float(casado.group(1)) * fator, base
+
+    casado = _NUA.fullmatch(alvo.strip().lower())
+    if casado:
+        fator, base = _UNIDADES[casado.group(1).lower()]
+        return fator, base
+
+    return None
+
+
+def extrair_do_titulo(titulo: str | None) -> tuple[float | None, str | None, str]:
+    """Separa a quantidade do resto do título.
+
+    Devolve (quantidade, unidade, titulo_sem_quantidade). O terceiro item é o
+    que deve alimentar a comparação textual na fase 4 — comparar títulos com a
+    gramatura dentro é justamente o que faz 'Leite 1L' pontuar alto contra
+    'Leite 200ml'.
+
+        >>> extrair_do_titulo("Leite Italac Integral 1L")
+        (1000.0, 'ml', 'Leite Italac Integral')
+    """
+    if not titulo:
+        return None, None, ""
+
+    alvo = str(titulo).strip()
+
+    for padrao in (_MULTIPLO, _SIMPLES):
+        casado = padrao.search(alvo)
+        if not casado:
+            continue
+        resultado = parse_quantidade(casado.group(0))
+        if resultado is None:
+            continue
+        restante = (alvo[: casado.start()] + " " + alvo[casado.end() :]).strip()
+        restante = re.sub(r"\s{2,}", " ", restante).strip(" -–—,")
+        return resultado[0], resultado[1], restante
+
+    # Título terminando em unidade nua: "Banana Prata kg"
+    tokens = alvo.split()
+    if tokens and tokens[-1].lower() in _UNIDADES:
+        fator, base = _UNIDADES[tokens[-1].lower()]
+        return fator, base, " ".join(tokens[:-1]).strip(" -–—,")
+
+    return None, None, alvo
+
+
+def preco_por_unidade(preco_centavos: int, quantidade: float | None, unidade: str | None) -> float | None:
+    """Preço por kg, litro ou unidade — em centavos.
+
+    É o que torna embalagens de tamanhos diferentes comparáveis entre si.
+    """
+    if not quantidade or quantidade <= 0 or not unidade:
+        return None
+    if unidade in ("g", "ml"):
+        return preco_centavos * 1000.0 / quantidade
+    return preco_centavos / quantidade

--- a/precos/normalize/texto.py
+++ b/precos/normalize/texto.py
@@ -1,0 +1,144 @@
+"""Normalização de texto e de códigos EAN/GTIN."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Abreviações comuns em título de produto de supermercado.
+ABREVIACOES = {
+    "int": "integral",
+    "desn": "desnatado",
+    "semi": "semidesnatado",
+    "ref": "refrigerante",
+    "refri": "refrigerante",
+    "achoc": "achocolatado",
+    "choc": "chocolate",
+    "past": "pasteurizado",
+    "cong": "congelado",
+    "trad": "tradicional",
+    "sab": "sabor",
+    "c/": "com",
+    "s/": "sem",
+    "p/": "para",
+    "pc": "pacote",
+    "pct": "pacote",
+    "cx": "caixa",
+    "gf": "garrafa",
+    "lt": "lata",
+    "und": "unidade",
+    "un": "unidade",
+    "unid": "unidade",
+}
+
+_ESPACOS = re.compile(r"\s+")
+_PONTUACAO = re.compile(r"[^\w\s%]", re.UNICODE)
+
+
+def remover_acentos(texto: str) -> str:
+    """'Café Torrado' -> 'Cafe Torrado'."""
+    decomposto = unicodedata.normalize("NFKD", texto)
+    return "".join(c for c in decomposto if not unicodedata.combining(c))
+
+
+def expandir_abreviacoes(texto: str) -> str:
+    """Troca abreviações por palavras inteiras, token a token.
+
+    Feito antes de remover pontuação, porque abreviações como 'c/' dependem
+    da barra para serem reconhecidas.
+    """
+    tokens = texto.split()
+    saida = []
+    for token in tokens:
+        chave = token.lower().rstrip(".")
+        saida.append(ABREVIACOES.get(chave, token))
+    return " ".join(saida)
+
+
+def normalizar_titulo(texto: str | None) -> str:
+    """Forma canônica de um título, usada como chave de alias.
+
+    Minúsculas, sem acentos, sem pontuação, abreviações expandidas e espaços
+    colapsados. Duas grafias do mesmo produto devem convergir para a mesma
+    string.
+    """
+    if not texto:
+        return ""
+    resultado = expandir_abreviacoes(str(texto).strip())
+    resultado = remover_acentos(resultado).lower()
+    resultado = _PONTUACAO.sub(" ", resultado)
+    return _ESPACOS.sub(" ", resultado).strip()
+
+
+# --------------------------------------------------------------------------
+# EAN / GTIN
+# --------------------------------------------------------------------------
+
+_COMPRIMENTOS_VALIDOS = (8, 12, 13, 14)
+
+
+def normalizar_ean(valor: object) -> str | None:
+    """Devolve o EAN como string de dígitos, ou None se não der para aproveitar.
+
+    Existe por causa de um problema concreto de planilha: o Excel trata código
+    de barras como número, e o que chega aqui é '7891234567890.0' ou
+    '7.89123E+12'. Gravar isso cru corrompe a base em silêncio.
+    """
+    if valor is None:
+        return None
+
+    if isinstance(valor, float):
+        # 7891234567890.0 -> "7891234567890"; notação científica também resolve
+        if valor != valor or valor in (float("inf"), float("-inf")):  # NaN/inf
+            return None
+        texto = f"{valor:.0f}"
+    elif isinstance(valor, int) and not isinstance(valor, bool):
+        texto = str(valor)
+    else:
+        texto = str(valor).strip()
+        if not texto:
+            return None
+        # "7.89123E+12" vindo de planilha
+        if re.fullmatch(r"\d+(?:\.\d+)?[eE][+-]?\d+", texto):
+            try:
+                texto = f"{float(texto):.0f}"
+            except (ValueError, OverflowError):
+                return None
+        # "7891234567890.0"
+        elif re.fullmatch(r"\d+\.0+", texto):
+            texto = texto.split(".")[0]
+
+    digitos = re.sub(r"\D", "", texto)
+    if not digitos:
+        return None
+
+    # Códigos internos de balança e afins são curtos demais para ser GTIN.
+    if len(digitos) < 8:
+        return None
+    if len(digitos) > 14:
+        return None
+
+    # EAN-13 exportado sem o zero à esquerda é o caso mais comum de "quase lá".
+    if len(digitos) not in _COMPRIMENTOS_VALIDOS:
+        alvo = next((c for c in _COMPRIMENTOS_VALIDOS if c > len(digitos)), None)
+        if alvo is None:
+            return None
+        digitos = digitos.zfill(alvo)
+
+    return digitos
+
+
+def validar_ean(ean: str | None) -> bool:
+    """Confere o dígito verificador do GTIN (EAN-8/12/13/14)."""
+    if not ean or not ean.isdigit() or len(ean) not in _COMPRIMENTOS_VALIDOS:
+        return False
+
+    corpo, verificador = ean[:-1], int(ean[-1])
+    # Da direita para a esquerda no corpo, pesos alternam 3 e 1.
+    soma = 0
+    for posicao, digito in enumerate(reversed(corpo)):
+        peso = 3 if posicao % 2 == 0 else 1
+        soma += int(digito) * peso
+
+    esperado = (10 - (soma % 10)) % 10
+    return esperado == verificador

--- a/precos/requirements.txt
+++ b/precos/requirements.txt
@@ -1,0 +1,8 @@
+# Coletor VTEX (F02)
+requests>=2.31
+
+# Opcional — só para importar planilha .xlsx. CSV funciona sem nada instalado.
+# openpyxl>=3.1
+
+# Fase 4 (matching), ainda não implementada:
+# rapidfuzz>=3.6

--- a/precos/servicos.py
+++ b/precos/servicos.py
@@ -1,0 +1,175 @@
+"""Orquestração: liga coletores ao banco.
+
+Fica fora do `cli.py` para poder ser testado sem simular linha de comando, e
+fora dos coletores para manter a regra de que coletor não escreve no banco.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import config
+from .collectors.base import ColetaAnomala, ErroDeColeta, OfertaBruta
+from .collectors.planilha import ler_planilha
+from .collectors.vtex import ColetorVtex
+from .normalize.quantidades import extrair_do_titulo, preco_por_unidade
+from .storage import repositories as repo
+
+SLUG_PLANILHA = "planilha"
+
+
+@dataclass
+class ResultadoImportacao:
+    execucao_id: int
+    produtos_novos: int
+    produtos_atualizados: int
+    precos_registrados: int
+    descartadas: list[tuple[int, str]]
+    ean_sem_digito_valido: int
+    colunas_detectadas: dict[str, str]
+
+
+@dataclass
+class ResultadoColeta:
+    execucao_id: int
+    fonte: str
+    ofertas: int
+    com_ean: int
+
+
+def importar_planilha(conn: sqlite3.Connection, caminho: Path | str) -> ResultadoImportacao:
+    """F01 — carrega a planilha de referência.
+
+    Diferença central em relação à v1: o preço da planilha não é gravado como
+    uma coluna sobrescrevível em `produtos`. Ele entra na série histórica como
+    mais uma observação, de uma fonte chamada 'planilha'. A referência passa a
+    ser derivada do histórico (repositories.preco_referencia).
+    """
+    leitura = ler_planilha(caminho)
+
+    fonte_id = repo.obter_ou_criar_fonte(
+        conn, SLUG_PLANILHA, "Planilha de referência", "planilha"
+    )
+    loja_id = repo.obter_ou_criar_loja(conn, fonte_id, "referencia", "Planilha de referência")
+    execucao_id = repo.iniciar_execucao(conn, fonte_id, "import")
+
+    novos = atualizados = 0
+    registros: list[tuple] = []
+
+    try:
+        for linha in leitura.linhas:
+            produto_id, criado = repo.upsert_produto(
+                conn,
+                nome=linha.nome,
+                ean=linha.ean,
+                marca=linha.marca,
+                categoria=linha.categoria,
+                quantidade=linha.quantidade,
+                unidade=linha.unidade,
+            )
+            if criado:
+                novos += 1
+            else:
+                atualizados += 1
+
+            registros.append(
+                (
+                    produto_id,
+                    loja_id,
+                    None,
+                    linha.preco_centavos,
+                    preco_por_unidade(linha.preco_centavos, linha.quantidade, linha.unidade),
+                )
+            )
+
+        gravados = repo.registrar_precos(conn, registros)
+        conn.commit()
+        repo.concluir_execucao(conn, execucao_id, gravados)
+    except Exception as erro:
+        conn.rollback()
+        repo.falhar_execucao(conn, execucao_id, f"{type(erro).__name__}: {erro}")
+        raise
+
+    return ResultadoImportacao(
+        execucao_id=execucao_id,
+        produtos_novos=novos,
+        produtos_atualizados=atualizados,
+        precos_registrados=gravados,
+        descartadas=leitura.descartadas,
+        ean_sem_digito_valido=leitura.ean_sem_digito_valido,
+        colunas_detectadas=leitura.colunas_detectadas,
+    )
+
+
+def coletar_vtex(
+    conn: sqlite3.Connection,
+    slug: str,
+    *,
+    limite: int | None = None,
+    sessao=None,
+) -> ResultadoColeta:
+    """F02 — coleta uma loja VTEX e grava as ofertas brutas.
+
+    Nada de pareamento aqui: a oferta é gravada como veio. O vínculo com a base
+    é responsabilidade da fase 4, e mantê-lo separado é o que permite rodar um
+    matcher melhor sobre dados já coletados, sem repetir a coleta.
+    """
+    if slug not in config.FONTES_VTEX:
+        conhecidas = ", ".join(sorted(config.FONTES_VTEX)) or "(nenhuma)"
+        raise ValueError(f"fonte VTEX desconhecida: {slug}. Configuradas: {conhecidas}")
+
+    fonte_cfg = config.FONTES_VTEX[slug]
+    fonte_id = repo.obter_ou_criar_fonte(conn, fonte_cfg.slug, fonte_cfg.nome, "varejo_online")
+    loja_id = repo.obter_ou_criar_loja(
+        conn, fonte_id, fonte_cfg.codigo_loja, fonte_cfg.nome_loja
+    )
+    execucao_id = repo.iniciar_execucao(conn, fonte_id, "catalogo")
+
+    try:
+        coletor = ColetorVtex(fonte_cfg, sessao=sessao, limite=limite)
+        ofertas = coletor.coletar()
+    except ColetaAnomala as erro:
+        # Health check do PRD §5.1: falha ALTO, não grava vazio em silêncio.
+        repo.falhar_execucao(conn, execucao_id, str(erro))
+        raise
+    except ErroDeColeta as erro:
+        repo.falhar_execucao(conn, execucao_id, f"{type(erro).__name__}: {erro}")
+        raise
+
+    try:
+        persistiveis = [
+            repo.OfertaPersistivel(
+                loja_id=loja_id,
+                titulo_original=o.titulo_original,
+                preco_centavos=o.preco_centavos,
+                ean_informado=o.ean_informado,
+                preco_de_centavos=o.preco_de_centavos,
+                disponivel=o.disponivel,
+                url=o.url,
+                payload_bruto=o.payload_bruto,
+            )
+            for o in ofertas
+        ]
+        gravadas = repo.inserir_ofertas(conn, execucao_id, persistiveis)
+        conn.commit()
+        repo.concluir_execucao(conn, execucao_id, gravadas)
+    except Exception as erro:
+        conn.rollback()
+        repo.falhar_execucao(conn, execucao_id, f"{type(erro).__name__}: {erro}")
+        raise
+
+    return ResultadoColeta(
+        execucao_id=execucao_id,
+        fonte=slug,
+        ofertas=gravadas,
+        com_ean=sum(1 for o in ofertas if o.ean_informado),
+    )
+
+
+def resumo_oferta(oferta: OfertaBruta) -> str:
+    """Linha legível de uma oferta — usada pelo CLI."""
+    quantidade, unidade, _ = extrair_do_titulo(oferta.titulo_original)
+    medida = f" [{quantidade:g}{unidade}]" if quantidade and unidade else ""
+    return f"{oferta.titulo_original}{medida}"

--- a/precos/storage/__init__.py
+++ b/precos/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Persistência. Nenhum SQL solto fora deste pacote (PRD v2 §5)."""

--- a/precos/storage/db.py
+++ b/precos/storage/db.py
@@ -1,0 +1,67 @@
+"""Conexão e migração do banco."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from .. import config
+
+SCHEMA = Path(__file__).with_name("schema.sql")
+
+
+def conectar(caminho: Path | str | None = None) -> sqlite3.Connection:
+    """Abre uma conexão já configurada.
+
+    `PRAGMA foreign_keys = ON` é obrigatório em TODA conexão: no SQLite a
+    checagem vem desligada por padrão, e sem ela as foreign keys do schema são
+    decorativas — foi um dos defeitos apontados na revisão do PRD v1.
+    """
+    destino = Path(caminho) if caminho is not None else config.DB_PATH
+    if destino.parent != Path("") and str(destino) != ":memory:":
+        destino.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(destino))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
+def migrar(conn: sqlite3.Connection) -> None:
+    """Aplica o schema. Idempotente — todo objeto usa IF NOT EXISTS."""
+    conn.executescript(SCHEMA.read_text(encoding="utf-8"))
+    # executescript faz commit implícito, mas o PRAGMA de FK é por conexão e
+    # o script o redefine; garantimos o estado final.
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.commit()
+
+
+@contextmanager
+def sessao(caminho: Path | str | None = None) -> Iterator[sqlite3.Connection]:
+    """Conexão migrada, com commit no sucesso e rollback no erro."""
+    conn = conectar(caminho)
+    try:
+        migrar(conn)
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def backup(conn: sqlite3.Connection, destino: Path | str) -> None:
+    """Cópia consistente com o banco em uso (PRD v2 §7).
+
+    A série histórica leva meses para ser reconstruída, se é que pode. Isso
+    aqui deve rodar desde o primeiro dia, para fora da máquina.
+    """
+    alvo = Path(destino)
+    alvo.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(alvo)) as saida:
+        conn.backup(saida)

--- a/precos/storage/repositories.py
+++ b/precos/storage/repositories.py
@@ -1,0 +1,277 @@
+"""Queries nomeadas. É o único lugar do sistema que escreve SQL."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+# --------------------------------------------------------------------------
+# Fontes e lojas
+# --------------------------------------------------------------------------
+
+
+def obter_ou_criar_fonte(conn: sqlite3.Connection, slug: str, nome: str, tipo: str) -> int:
+    linha = conn.execute("SELECT id FROM fontes WHERE slug = ?", (slug,)).fetchone()
+    if linha:
+        return int(linha["id"])
+    cursor = conn.execute(
+        "INSERT INTO fontes (slug, nome, tipo) VALUES (?, ?, ?)", (slug, nome, tipo)
+    )
+    return int(cursor.lastrowid)
+
+
+def obter_ou_criar_loja(
+    conn: sqlite3.Connection,
+    fonte_id: int,
+    codigo_externo: str,
+    nome: str,
+    *,
+    cidade: str | None = None,
+    uf: str | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
+) -> int:
+    linha = conn.execute(
+        "SELECT id FROM lojas WHERE fonte_id = ? AND codigo_externo = ?",
+        (fonte_id, codigo_externo),
+    ).fetchone()
+    if linha:
+        return int(linha["id"])
+    cursor = conn.execute(
+        """INSERT INTO lojas (fonte_id, codigo_externo, nome, cidade, uf, latitude, longitude)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (fonte_id, codigo_externo, nome, cidade, uf, latitude, longitude),
+    )
+    return int(cursor.lastrowid)
+
+
+# --------------------------------------------------------------------------
+# Produtos
+# --------------------------------------------------------------------------
+
+
+def upsert_produto(
+    conn: sqlite3.Connection,
+    *,
+    nome: str,
+    ean: str | None = None,
+    marca: str | None = None,
+    categoria: str | None = None,
+    quantidade: float | None = None,
+    unidade: str | None = None,
+) -> tuple[int, bool]:
+    """Insere ou atualiza um produto. Devolve (id, foi_criado).
+
+    Chaveia por EAN quando existe. Sem EAN (hortifruti, açougue, granel) o
+    produto continua tendo lugar na base — era o que a PRIMARY KEY em `ean` da
+    v1 impedia — e a deduplicação passa a ser por nome.
+    """
+    if ean:
+        linha = conn.execute("SELECT id FROM produtos WHERE ean = ?", (ean,)).fetchone()
+    else:
+        linha = conn.execute(
+            "SELECT id FROM produtos WHERE ean IS NULL AND lower(nome) = lower(?)", (nome,)
+        ).fetchone()
+
+    if linha:
+        produto_id = int(linha["id"])
+        conn.execute(
+            """UPDATE produtos
+                  SET nome = ?,
+                      marca = COALESCE(?, marca),
+                      categoria = COALESCE(?, categoria),
+                      quantidade = COALESCE(?, quantidade),
+                      unidade = COALESCE(?, unidade),
+                      atualizado_em = datetime('now')
+                WHERE id = ?""",
+            (nome, marca, categoria, quantidade, unidade, produto_id),
+        )
+        return produto_id, False
+
+    cursor = conn.execute(
+        """INSERT INTO produtos (ean, nome, marca, categoria, quantidade, unidade)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (ean, nome, marca, categoria, quantidade, unidade),
+    )
+    return int(cursor.lastrowid), True
+
+
+def contar_produtos(conn: sqlite3.Connection) -> int:
+    return int(conn.execute("SELECT COUNT(*) AS n FROM produtos").fetchone()["n"])
+
+
+# --------------------------------------------------------------------------
+# Execuções
+# --------------------------------------------------------------------------
+
+
+def iniciar_execucao(conn: sqlite3.Connection, fonte_id: int | None, tipo: str) -> int:
+    cursor = conn.execute(
+        "INSERT INTO execucoes (fonte_id, tipo, status) VALUES (?, ?, 'running')",
+        (fonte_id, tipo),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def concluir_execucao(conn: sqlite3.Connection, execucao_id: int, itens: int) -> None:
+    conn.execute(
+        """UPDATE execucoes
+              SET status = 'completed', itens_coletados = ?, concluida_em = datetime('now')
+            WHERE id = ?""",
+        (itens, execucao_id),
+    )
+    conn.commit()
+
+
+def falhar_execucao(conn: sqlite3.Connection, execucao_id: int, erro: str, itens: int = 0) -> None:
+    conn.execute(
+        """UPDATE execucoes
+              SET status = 'failed', erro = ?, itens_coletados = ?, concluida_em = datetime('now')
+            WHERE id = ?""",
+        (erro[:2000], itens, execucao_id),
+    )
+    conn.commit()
+
+
+def ultimas_execucoes(conn: sqlite3.Connection, limite: int = 10) -> list[sqlite3.Row]:
+    return conn.execute(
+        """SELECT e.id, e.tipo, e.status, e.itens_coletados, e.erro,
+                  e.iniciada_em, e.concluida_em, f.slug AS fonte
+             FROM execucoes e
+             LEFT JOIN fontes f ON f.id = e.fonte_id
+            ORDER BY e.iniciada_em DESC
+            LIMIT ?""",
+        (limite,),
+    ).fetchall()
+
+
+# --------------------------------------------------------------------------
+# Ofertas brutas
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OfertaPersistivel:
+    loja_id: int
+    titulo_original: str
+    preco_centavos: int
+    ean_informado: str | None = None
+    preco_de_centavos: int | None = None
+    disponivel: bool = True
+    url: str | None = None
+    payload_bruto: str | None = None
+
+
+def inserir_ofertas(
+    conn: sqlite3.Connection, execucao_id: int, ofertas: Sequence[OfertaPersistivel]
+) -> int:
+    """Grava as ofertas brutas em lote.
+
+    A oferta é sempre gravada, mesmo sem pareamento com um produto conhecido —
+    inclusive quando o EAN é desconhecido. Perder o dado bruto justamente no
+    caso de produto novo era o efeito da foreign key da v1.
+    """
+    if not ofertas:
+        return 0
+    conn.executemany(
+        """INSERT INTO ofertas (execucao_id, loja_id, titulo_original, ean_informado,
+                                preco_centavos, preco_de_centavos, disponivel, url, payload_bruto)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        [
+            (
+                execucao_id,
+                o.loja_id,
+                o.titulo_original,
+                o.ean_informado,
+                o.preco_centavos,
+                o.preco_de_centavos,
+                1 if o.disponivel else 0,
+                o.url,
+                o.payload_bruto,
+            )
+            for o in ofertas
+        ],
+    )
+    return len(ofertas)
+
+
+def contar_ofertas(conn: sqlite3.Connection, execucao_id: int | None = None) -> int:
+    if execucao_id is None:
+        linha = conn.execute("SELECT COUNT(*) AS n FROM ofertas").fetchone()
+    else:
+        linha = conn.execute(
+            "SELECT COUNT(*) AS n FROM ofertas WHERE execucao_id = ?", (execucao_id,)
+        ).fetchone()
+    return int(linha["n"])
+
+
+# --------------------------------------------------------------------------
+# Série histórica
+# --------------------------------------------------------------------------
+
+
+def registrar_preco(
+    conn: sqlite3.Connection,
+    *,
+    produto_id: int,
+    loja_id: int,
+    preco_centavos: int,
+    preco_por_unidade: float | None = None,
+    oferta_id: int | None = None,
+) -> int:
+    cursor = conn.execute(
+        """INSERT INTO precos_coletados
+               (produto_id, loja_id, oferta_id, preco_centavos, preco_por_unidade)
+           VALUES (?, ?, ?, ?, ?)""",
+        (produto_id, loja_id, oferta_id, preco_centavos, preco_por_unidade),
+    )
+    return int(cursor.lastrowid)
+
+
+def registrar_precos(conn: sqlite3.Connection, registros: Iterable[tuple]) -> int:
+    """Lote de (produto_id, loja_id, oferta_id, preco_centavos, preco_por_unidade)."""
+    linhas = list(registros)
+    if not linhas:
+        return 0
+    conn.executemany(
+        """INSERT INTO precos_coletados
+               (produto_id, loja_id, oferta_id, preco_centavos, preco_por_unidade)
+           VALUES (?, ?, ?, ?, ?)""",
+        linhas,
+    )
+    return len(linhas)
+
+
+# Mediana e p25 dos últimos 90 dias. O SQLite não tem MEDIAN nativo; a janela
+# resolve. Substitui a coluna `preco_referencia` fixa da v1.
+_SQL_REFERENCIA = """
+WITH r AS (
+  SELECT preco_centavos,
+         PERCENT_RANK() OVER (ORDER BY preco_centavos) AS pr
+  FROM precos_coletados
+  WHERE produto_id = :produto_id
+    AND coletado_em >= datetime('now', :janela)
+)
+SELECT COUNT(*) AS amostras,
+       MIN(preco_centavos) AS minimo,
+       MAX(CASE WHEN pr <= 0.50 THEN preco_centavos END) AS mediana,
+       MAX(CASE WHEN pr <= 0.25 THEN preco_centavos END) AS p25
+FROM r
+"""
+
+
+def preco_referencia(
+    conn: sqlite3.Connection, produto_id: int, dias: int = 90
+) -> dict[str, int | None]:
+    linha = conn.execute(
+        _SQL_REFERENCIA, {"produto_id": produto_id, "janela": f"-{dias} days"}
+    ).fetchone()
+    return {
+        "amostras": int(linha["amostras"] or 0),
+        "minimo": linha["minimo"],
+        "mediana": linha["mediana"],
+        "p25": linha["p25"],
+    }

--- a/precos/storage/schema.sql
+++ b/precos/storage/schema.sql
@@ -1,0 +1,158 @@
+PRAGMA foreign_keys = ON;   -- OBRIGATÓRIO em toda conexão: no SQLite vem desligado por padrão
+PRAGMA journal_mode = WAL;
+
+-- ============================================================
+-- DIMENSÕES
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS fontes (
+    id            INTEGER PRIMARY KEY,
+    slug          TEXT NOT NULL UNIQUE,
+    nome          TEXT NOT NULL,
+    tipo          TEXT NOT NULL CHECK (tipo IN ('marketplace', 'varejo_online', 'planilha', 'orgao_publico')),
+    ativa         INTEGER NOT NULL DEFAULT 1 CHECK (ativa IN (0, 1)),
+    criada_em     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Preço é sempre um fato de (produto, LOJA, momento) — nunca um atributo do produto.
+CREATE TABLE IF NOT EXISTS lojas (
+    id             INTEGER PRIMARY KEY,
+    fonte_id       INTEGER NOT NULL REFERENCES fontes(id) ON DELETE CASCADE,
+    codigo_externo TEXT,
+    nome           TEXT NOT NULL,
+    cidade         TEXT,
+    uf             TEXT CHECK (uf IS NULL OR length(uf) = 2),
+    latitude       REAL,
+    longitude      REAL,
+    criada_em      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (fonte_id, codigo_externo)
+);
+
+-- id surrogate: hortifruti/granel não têm EAN e precisam existir na base.
+-- quantidade+unidade são CAMPOS, não texto — é o que viabiliza o portão de unidade do matcher.
+CREATE TABLE IF NOT EXISTS produtos (
+    id            INTEGER PRIMARY KEY,
+    ean           TEXT,
+    nome          TEXT NOT NULL,
+    marca         TEXT,
+    categoria     TEXT,
+    quantidade    REAL,                    -- sempre normalizada para a unidade base
+    unidade       TEXT CHECK (unidade IS NULL OR unidade IN ('g', 'ml', 'un')),
+    monitorado    INTEGER NOT NULL DEFAULT 1 CHECK (monitorado IN (0, 1)),
+    criado_em     TEXT NOT NULL DEFAULT (datetime('now')),
+    atualizado_em TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Índice único PARCIAL: garante EAN único quando existe, e permite N produtos sem EAN.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_produtos_ean
+    ON produtos(ean) WHERE ean IS NOT NULL;
+CREATE INDEX IF NOT EXISTS ix_produtos_marca ON produtos(marca);
+CREATE INDEX IF NOT EXISTS ix_produtos_monitorado ON produtos(monitorado) WHERE monitorado = 1;
+
+-- ============================================================
+-- EXECUÇÕES — mesmo padrão de sync_logs em database/migrations/001_init.sql
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS execucoes (
+    id              INTEGER PRIMARY KEY,
+    fonte_id        INTEGER REFERENCES fontes(id) ON DELETE SET NULL,
+    tipo            TEXT NOT NULL CHECK (tipo IN ('watchlist', 'catalogo', 'manual', 'import')),
+    status          TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed')),
+    itens_coletados INTEGER NOT NULL DEFAULT 0,
+    erro            TEXT,
+    iniciada_em     TEXT NOT NULL DEFAULT (datetime('now')),
+    concluida_em    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS ix_execucoes_fonte_data ON execucoes(fonte_id, iniciada_em DESC);
+
+-- ============================================================
+-- FATO: OFERTAS BRUTAS (append-only, imutável)
+-- Sem FK para produtos: a oferta é gravada SEMPRE, mesmo sem pareamento.
+-- payload_bruto permite re-parsear histórico sem re-coletar.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ofertas (
+    id                INTEGER PRIMARY KEY,
+    execucao_id       INTEGER NOT NULL REFERENCES execucoes(id) ON DELETE CASCADE,
+    loja_id           INTEGER NOT NULL REFERENCES lojas(id) ON DELETE CASCADE,
+    titulo_original   TEXT NOT NULL,
+    ean_informado     TEXT,
+    preco_centavos    INTEGER NOT NULL CHECK (preco_centavos > 0),
+    preco_de_centavos INTEGER CHECK (preco_de_centavos IS NULL OR preco_de_centavos > 0),
+    disponivel        INTEGER NOT NULL DEFAULT 1 CHECK (disponivel IN (0, 1)),
+    url               TEXT,
+    payload_bruto     TEXT,
+    coletada_em       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_ofertas_execucao  ON ofertas(execucao_id);
+CREATE INDEX IF NOT EXISTS ix_ofertas_loja_data ON ofertas(loja_id, coletada_em DESC);
+CREATE INDEX IF NOT EXISTS ix_ofertas_ean       ON ofertas(ean_informado) WHERE ean_informado IS NOT NULL;
+
+-- ============================================================
+-- PAREAMENTO
+-- ============================================================
+
+-- Cada confirmação humana vira memória permanente. É a camada que faz o sistema
+-- ficar mais preciso com o uso, em vez de repetir o mesmo fuzzy para sempre.
+CREATE TABLE IF NOT EXISTS produto_aliases (
+    id             INTEGER PRIMARY KEY,
+    produto_id     INTEGER NOT NULL REFERENCES produtos(id) ON DELETE CASCADE,
+    fonte_id       INTEGER NOT NULL REFERENCES fontes(id) ON DELETE CASCADE,
+    titulo_norm    TEXT NOT NULL,
+    confirmado_por TEXT NOT NULL DEFAULT 'humano',
+    criado_em      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (fonte_id, titulo_norm)
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+    id         INTEGER PRIMARY KEY,
+    oferta_id  INTEGER NOT NULL REFERENCES ofertas(id) ON DELETE CASCADE,
+    produto_id INTEGER REFERENCES produtos(id) ON DELETE SET NULL,
+    metodo     TEXT NOT NULL CHECK (metodo IN ('alias', 'ean', 'fuzzy')),
+    score      REAL CHECK (score IS NULL OR (score >= 0 AND score <= 100)),
+    status     TEXT NOT NULL CHECK (status IN ('auto', 'revisar', 'confirmado', 'rejeitado')),
+    criado_em  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (oferta_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_matches_produto ON matches(produto_id);
+CREATE INDEX IF NOT EXISTS ix_matches_revisar ON matches(status) WHERE status = 'revisar';
+
+-- ============================================================
+-- FATO: SÉRIE HISTÓRICA — o ativo do projeto
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS precos_coletados (
+    id                INTEGER PRIMARY KEY,
+    produto_id        INTEGER NOT NULL REFERENCES produtos(id) ON DELETE CASCADE,
+    loja_id           INTEGER NOT NULL REFERENCES lojas(id) ON DELETE CASCADE,
+    oferta_id         INTEGER REFERENCES ofertas(id) ON DELETE SET NULL,
+    preco_centavos    INTEGER NOT NULL CHECK (preco_centavos > 0),
+    preco_por_unidade REAL,               -- R$/kg ou R$/L: torna embalagens comparáveis
+    coletado_em       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_precos_produto_data ON precos_coletados(produto_id, coletado_em DESC);
+CREATE INDEX IF NOT EXISTS ix_precos_loja_data    ON precos_coletados(loja_id, coletado_em DESC);
+
+-- ============================================================
+-- ALERTAS — alert_key UNIQUE é o que impede spam
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS alertas (
+    id                  INTEGER PRIMARY KEY,
+    alert_key           TEXT NOT NULL UNIQUE,
+    produto_id          INTEGER NOT NULL REFERENCES produtos(id) ON DELETE CASCADE,
+    loja_id             INTEGER NOT NULL REFERENCES lojas(id) ON DELETE CASCADE,
+    oferta_id           INTEGER REFERENCES ofertas(id) ON DELETE SET NULL,
+    preco_centavos      INTEGER NOT NULL,
+    referencia_centavos INTEGER NOT NULL,
+    economia_pct        REAL NOT NULL,
+    economia_centavos   INTEGER NOT NULL,
+    enviado_em          TEXT NOT NULL DEFAULT (datetime('now')),
+    feedback            TEXT CHECK (feedback IS NULL OR feedback IN ('util', 'irrelevante', 'errado'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_alertas_produto_data ON alertas(produto_id, enviado_em DESC);

--- a/precos/tests/__init__.py
+++ b/precos/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Testes. Rodam com a biblioteca padrão: python -m unittest discover precos"""

--- a/precos/tests/test_planilha.py
+++ b/precos/tests/test_planilha.py
@@ -1,0 +1,120 @@
+"""Importação de planilha (F01) — inclusive os defeitos da v1."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from ..collectors.planilha import ErroDePlanilha, ler_planilha
+
+
+def escrever(conteudo: str, sufixo: str = ".csv") -> Path:
+    arquivo = tempfile.NamedTemporaryFile("w", suffix=sufixo, delete=False, encoding="utf-8")
+    arquivo.write(conteudo)
+    arquivo.close()
+    return Path(arquivo.name)
+
+
+class TestLerPlanilha(unittest.TestCase):
+    def test_colunas_da_spec_do_prd(self):
+        caminho = escrever(
+            "EAN,Nome,Preco_Referencia\n7891234567895,Leite Italac Integral 1L,5.99\n"
+        )
+        resultado = ler_planilha(caminho)
+        self.assertEqual(len(resultado.linhas), 1)
+        linha = resultado.linhas[0]
+        self.assertEqual(linha.ean, "7891234567895")
+        self.assertEqual(linha.preco_centavos, 599)
+        self.assertEqual((linha.quantidade, linha.unidade), (1000.0, "ml"))
+
+    def test_coluna_preco_do_codigo_do_prd(self):
+        """A v1 divergia de si mesma: spec dizia Preco_Referencia, código lia Preco."""
+        caminho = escrever("EAN,Nome,Preco\n7891234567895,Leite 1L,5.99\n")
+        resultado = ler_planilha(caminho)
+        self.assertEqual(len(resultado.linhas), 1)
+        self.assertEqual(resultado.colunas_detectadas["preco"], "Preco")
+
+    def test_separador_ponto_e_virgula(self):
+        caminho = escrever("EAN;Nome;Preco\n7891234567895;Arroz 5kg;R$ 24,90\n")
+        resultado = ler_planilha(caminho)
+        self.assertEqual(resultado.linhas[0].preco_centavos, 2490)
+
+    def test_bom_do_excel(self):
+        caminho = escrever("﻿EAN,Nome,Preco\n7891234567895,Leite 1L,5.99\n")
+        self.assertEqual(len(ler_planilha(caminho).linhas), 1)
+
+    def test_preco_em_reais_com_simbolo(self):
+        caminho = escrever("EAN,Nome,Preco\n7891234567895,Leite 1L,\"R$ 1.234,56\"\n")
+        self.assertEqual(ler_planilha(caminho).linhas[0].preco_centavos, 123456)
+
+    def test_preco_vazio_e_descartado_com_motivo(self):
+        """Na v1 isso virava NaN, era gravado e sumia dos alertas em silêncio."""
+        caminho = escrever(
+            "EAN,Nome,Preco\n"
+            "7891234567895,Leite 1L,\n"
+            "7891234567895,Arroz 5kg,24.90\n"
+        )
+        resultado = ler_planilha(caminho)
+        self.assertEqual(len(resultado.linhas), 1)
+        self.assertEqual(len(resultado.descartadas), 1)
+        self.assertIn("preço ilegível", resultado.descartadas[0][1])
+        self.assertEqual(resultado.descartadas[0][0], 2)  # número da linha
+
+    def test_preco_zero_descartado(self):
+        caminho = escrever("EAN,Nome,Preco\n7891234567895,Leite 1L,0\n")
+        resultado = ler_planilha(caminho)
+        self.assertEqual(resultado.linhas, [])
+        self.assertIn("não positivo", resultado.descartadas[0][1])
+
+    def test_nome_vazio_descartado(self):
+        caminho = escrever("EAN,Nome,Preco\n7891234567895,,5.99\n")
+        self.assertIn("nome vazio", ler_planilha(caminho).descartadas[0][1])
+
+    def test_produto_sem_ean_e_aceito(self):
+        """Hortifruti não tem código de barras — a PK em `ean` da v1 o excluía."""
+        caminho = escrever("EAN,Nome,Preco\n,Banana Prata kg,7.90\n")
+        resultado = ler_planilha(caminho)
+        self.assertEqual(len(resultado.linhas), 1)
+        self.assertIsNone(resultado.linhas[0].ean)
+        self.assertEqual(resultado.linhas[0].quantidade, 1000.0)
+
+    def test_ean_corrompido_pelo_excel(self):
+        caminho = escrever("EAN,Nome,Preco\n7891234567895.0,Leite 1L,5.99\n")
+        self.assertEqual(ler_planilha(caminho).linhas[0].ean, "7891234567895")
+
+    def test_ean_com_digito_invalido_e_contado(self):
+        caminho = escrever("EAN,Nome,Preco\n7891234567890,Leite 1L,5.99\n")
+        resultado = ler_planilha(caminho)
+        self.assertEqual(resultado.ean_sem_digito_valido, 1)
+        self.assertTrue(resultado.linhas[0].ean_invalido)
+        self.assertEqual(len(resultado.linhas), 1)  # importado mesmo assim
+
+    def test_colunas_opcionais(self):
+        caminho = escrever(
+            "EAN,Nome,Preco,Marca,Categoria\n7891234567895,Leite 1L,5.99,Italac,Laticínios\n"
+        )
+        linha = ler_planilha(caminho).linhas[0]
+        self.assertEqual(linha.marca, "Italac")
+        self.assertEqual(linha.categoria, "Laticínios")
+
+    def test_cabecalho_acentuado(self):
+        caminho = escrever("Código,Descrição,Valor\n7891234567895,Leite 1L,5.99\n")
+        self.assertEqual(len(ler_planilha(caminho).linhas), 1)
+
+    def test_coluna_obrigatoria_ausente(self):
+        caminho = escrever("EAN,Observacao\n7891234567895,nada\n")
+        with self.assertRaises(ErroDePlanilha) as ctx:
+            ler_planilha(caminho)
+        self.assertIn("nome", str(ctx.exception))
+
+    def test_arquivo_inexistente(self):
+        with self.assertRaises(ErroDePlanilha):
+            ler_planilha(Path("/tmp/nao-existe-mesmo-12345.csv"))
+
+    def test_formato_nao_suportado(self):
+        caminho = escrever("qualquer coisa", sufixo=".pdf")
+        with self.assertRaises(ErroDePlanilha):
+            ler_planilha(caminho)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/precos/tests/test_precos.py
+++ b/precos/tests/test_precos.py
@@ -1,0 +1,72 @@
+"""Casos de parsing de preço listados no PRD v2 §5."""
+
+import unittest
+
+from ..normalize.precos import formatar_brl, parse_preco_brl
+
+
+class TestParsePrecoBrl(unittest.TestCase):
+    def test_milhar_com_centavos(self):
+        self.assertEqual(parse_preco_brl("R$ 1.234,56"), 123456)
+
+    def test_valor_simples(self):
+        self.assertEqual(parse_preco_brl("R$ 12,34"), 1234)
+
+    def test_preco_por_medida(self):
+        self.assertEqual(parse_preco_brl("R$ 9,90 /kg"), 990)
+        self.assertEqual(parse_preco_brl("R$ 4,50 a unidade"), 450)
+        self.assertEqual(parse_preco_brl("R$ 7,20 por litro"), 720)
+
+    def test_espaco_nao_separavel(self):
+        # \xa0 é o que o HTML de e-commerce costuma usar depois do "R$"
+        self.assertEqual(parse_preco_brl("R$\xa012,34"), 1234)
+        self.assertEqual(parse_preco_brl("R$ 1.234,56"), 123456)
+
+    def test_centavos_em_elemento_separado(self):
+        # Sem tratamento, "R$ 12<sup>90</sup>" vira 1290 reais — erro de 100x.
+        self.assertEqual(parse_preco_brl("R$ 12<sup>90</sup>"), 1290)
+        self.assertEqual(parse_preco_brl("<span>R$ 5</span><sup>,49</sup>"), 549)
+        self.assertEqual(parse_preco_brl("R$ 1.234<small>56</small>"), 123456)
+
+    def test_ponto_decimal_de_api(self):
+        self.assertEqual(parse_preco_brl("12.90"), 1290)
+        self.assertEqual(parse_preco_brl("1.5"), 150)
+
+    def test_ponto_como_milhar(self):
+        self.assertEqual(parse_preco_brl("1.234"), 123400)
+        self.assertEqual(parse_preco_brl("1.234.567"), 123456700)
+
+    def test_numeros_sao_reais(self):
+        self.assertEqual(parse_preco_brl(12.9), 1290)
+        self.assertEqual(parse_preco_brl(5), 500)
+        self.assertEqual(parse_preco_brl(0.1), 10)
+
+    def test_precisao_de_centavos(self):
+        # O motivo de não usar float: 19.99*100 == 1998.9999999999998
+        self.assertEqual(parse_preco_brl(19.99), 1999)
+        self.assertEqual(parse_preco_brl("R$ 19,99"), 1999)
+
+    def test_sem_preco(self):
+        for entrada in (None, "", "   ", "grátis", "sob consulta", float("nan"), True):
+            with self.subTest(entrada=entrada):
+                self.assertIsNone(parse_preco_brl(entrada))
+
+    def test_inteiro_em_texto(self):
+        self.assertEqual(parse_preco_brl("R$ 15"), 1500)
+
+
+class TestFormatarBrl(unittest.TestCase):
+    def test_formata(self):
+        self.assertEqual(formatar_brl(1234), "R$ 12,34")
+        self.assertEqual(formatar_brl(123456), "R$ 1.234,56")
+        self.assertEqual(formatar_brl(5), "R$ 0,05")
+        self.assertEqual(formatar_brl(None), "—")
+
+    def test_ida_e_volta(self):
+        for centavos in (1, 99, 100, 1234, 123456, 100000000):
+            with self.subTest(centavos=centavos):
+                self.assertEqual(parse_preco_brl(formatar_brl(centavos)), centavos)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/precos/tests/test_quantidades.py
+++ b/precos/tests/test_quantidades.py
@@ -1,0 +1,87 @@
+"""Casos de quantidade listados no PRD v2 §5, mais o portão de unidade."""
+
+import unittest
+
+from ..normalize.quantidades import extrair_do_titulo, parse_quantidade, preco_por_unidade
+
+
+class TestParseQuantidade(unittest.TestCase):
+    def test_litro(self):
+        self.assertEqual(parse_quantidade("1L"), (1000.0, "ml"))
+
+    def test_grama(self):
+        self.assertEqual(parse_quantidade("200g"), (200.0, "g"))
+
+    def test_multiplo(self):
+        # 2x500ml = 1000ml no total: é o que permite comparar preço por litro
+        self.assertEqual(parse_quantidade("2x500ml"), (1000.0, "ml"))
+        self.assertEqual(parse_quantidade("6 x 1L"), (6000.0, "ml"))
+
+    def test_decimal_com_virgula(self):
+        self.assertEqual(parse_quantidade("1,5 L"), (1500.0, "ml"))
+
+    def test_unidade_nua(self):
+        self.assertEqual(parse_quantidade("kg"), (1000.0, "g"))
+
+    def test_conversoes(self):
+        self.assertEqual(parse_quantidade("2kg"), (2000.0, "g"))
+        self.assertEqual(parse_quantidade("500 MG"), (0.5, "g"))
+        self.assertEqual(parse_quantidade("12 un"), (12.0, "un"))
+        self.assertEqual(parse_quantidade("1 dz"), (12.0, "un"))
+
+    def test_sem_quantidade(self):
+        for entrada in (None, "", "leite", "promoção"):
+            with self.subTest(entrada=entrada):
+                self.assertIsNone(parse_quantidade(entrada))
+
+
+class TestExtrairDoTitulo(unittest.TestCase):
+    def test_separa_quantidade_do_nome(self):
+        self.assertEqual(
+            extrair_do_titulo("Leite Italac Integral 1L"),
+            (1000.0, "ml", "Leite Italac Integral"),
+        )
+
+    def test_quantidade_no_meio(self):
+        qtd, unidade, resto = extrair_do_titulo("Arroz Tio João 5kg Tipo 1")
+        self.assertEqual((qtd, unidade), (5000.0, "g"))
+        self.assertEqual(resto, "Arroz Tio João Tipo 1")
+
+    def test_produto_a_peso(self):
+        self.assertEqual(
+            extrair_do_titulo("Banana Prata kg"), (1000.0, "g", "Banana Prata")
+        )
+
+    def test_sem_quantidade_preserva_titulo(self):
+        self.assertEqual(extrair_do_titulo("Detergente Ypê"), (None, None, "Detergente Ypê"))
+
+    def test_o_falso_positivo_do_prd(self):
+        """200g × 500g: o par que o WRatio da v1 aceitava.
+
+        Com quantidade extraída como campo, o portão do matcher (fase 4) tem
+        como recusar: os títulos residuais são idênticos, as quantidades não.
+        """
+        a = extrair_do_titulo("Leite Italac Integral 1L")
+        b = extrair_do_titulo("Leite Italac Integral 200ml")
+        self.assertEqual(a[2], b[2])          # mesmo texto residual
+        self.assertNotEqual(a[0], b[0])       # quantidades diferentes
+        self.assertEqual(a[1], b[1])          # mesma unidade base
+
+
+class TestPrecoPorUnidade(unittest.TestCase):
+    def test_por_litro(self):
+        # R$ 5,99 por 1000ml -> R$ 5,99/L
+        self.assertAlmostEqual(preco_por_unidade(599, 1000.0, "ml"), 599.0)
+
+    def test_embalagens_diferentes_ficam_comparaveis(self):
+        grande = preco_por_unidade(1000, 2000.0, "g")   # R$10,00 / 2kg
+        pequena = preco_por_unidade(600, 1000.0, "g")   # R$ 6,00 / 1kg
+        self.assertLess(grande, pequena)
+
+    def test_sem_quantidade(self):
+        self.assertIsNone(preco_por_unidade(599, None, None))
+        self.assertIsNone(preco_por_unidade(599, 0, "g"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/precos/tests/test_storage.py
+++ b/precos/tests/test_storage.py
@@ -1,0 +1,160 @@
+"""Schema e repositórios — os defeitos do banco da v1, agora como teste."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from ..storage import db
+from ..storage import repositories as repo
+
+
+class BaseComBanco(unittest.TestCase):
+    def setUp(self):
+        self.conn = db.conectar(":memory:")
+        db.migrar(self.conn)
+        self.fonte_id = repo.obter_ou_criar_fonte(self.conn, "mambo", "Mambo", "varejo_online")
+        self.loja_id = repo.obter_ou_criar_loja(self.conn, self.fonte_id, "principal", "Mambo")
+
+    def tearDown(self):
+        self.conn.close()
+
+
+class TestSchema(BaseComBanco):
+    def test_foreign_keys_ligadas(self):
+        """Sem o PRAGMA, as FKs do schema são decorativas (defeito §2.4 da revisão)."""
+        ativo = self.conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        self.assertEqual(ativo, 1)
+
+    def test_fk_realmente_barra(self):
+        import sqlite3
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.conn.execute(
+                "INSERT INTO lojas (fonte_id, nome) VALUES (99999, 'fantasma')"
+            )
+
+    def test_migrar_e_idempotente(self):
+        db.migrar(self.conn)
+        db.migrar(self.conn)
+        self.assertEqual(repo.contar_produtos(self.conn), 0)
+
+    def test_varios_produtos_sem_ean(self):
+        """A PRIMARY KEY em `ean` da v1 excluía hortifruti, açougue e granel."""
+        repo.upsert_produto(self.conn, nome="Banana Prata kg")
+        repo.upsert_produto(self.conn, nome="Tomate Italiano kg")
+        self.assertEqual(repo.contar_produtos(self.conn), 2)
+
+    def test_ean_duplicado_barrado(self):
+        a, criado_a = repo.upsert_produto(self.conn, nome="Leite 1L", ean="7891234567895")
+        b, criado_b = repo.upsert_produto(self.conn, nome="Leite Italac 1L", ean="7891234567895")
+        self.assertEqual(a, b)
+        self.assertTrue(criado_a)
+        self.assertFalse(criado_b)
+        self.assertEqual(repo.contar_produtos(self.conn), 1)
+
+    def test_preco_nao_positivo_barrado(self):
+        import sqlite3
+
+        produto_id, _ = repo.upsert_produto(self.conn, nome="Leite 1L")
+        with self.assertRaises(sqlite3.IntegrityError):
+            repo.registrar_preco(
+                self.conn, produto_id=produto_id, loja_id=self.loja_id, preco_centavos=0
+            )
+
+
+class TestOfertas(BaseComBanco):
+    def test_oferta_sem_produto_conhecido_e_gravada(self):
+        """A FK da v1 descartava exatamente o caso interessante: produto novo."""
+        execucao_id = repo.iniciar_execucao(self.conn, self.fonte_id, "catalogo")
+        gravadas = repo.inserir_ofertas(
+            self.conn,
+            execucao_id,
+            [
+                repo.OfertaPersistivel(
+                    loja_id=self.loja_id,
+                    titulo_original="Produto Nunca Visto 500g",
+                    preco_centavos=1290,
+                    ean_informado="9999999999994",
+                )
+            ],
+        )
+        self.assertEqual(gravadas, 1)
+        self.assertEqual(repo.contar_ofertas(self.conn, execucao_id), 1)
+
+    def test_lote_vazio(self):
+        execucao_id = repo.iniciar_execucao(self.conn, self.fonte_id, "catalogo")
+        self.assertEqual(repo.inserir_ofertas(self.conn, execucao_id, []), 0)
+
+
+class TestExecucoes(BaseComBanco):
+    def test_ciclo_de_vida(self):
+        execucao_id = repo.iniciar_execucao(self.conn, self.fonte_id, "catalogo")
+        repo.concluir_execucao(self.conn, execucao_id, 42)
+        linha = repo.ultimas_execucoes(self.conn, 1)[0]
+        self.assertEqual(linha["status"], "completed")
+        self.assertEqual(linha["itens_coletados"], 42)
+        self.assertIsNotNone(linha["concluida_em"])
+
+    def test_falha_registra_motivo(self):
+        execucao_id = repo.iniciar_execucao(self.conn, self.fonte_id, "catalogo")
+        repo.falhar_execucao(self.conn, execucao_id, "coleta anômala: 0 itens")
+        linha = repo.ultimas_execucoes(self.conn, 1)[0]
+        self.assertEqual(linha["status"], "failed")
+        self.assertIn("anômala", linha["erro"])
+
+
+class TestPrecoReferencia(BaseComBanco):
+    def test_derivado_do_historico(self):
+        """Substitui a coluna `preco_referencia` sobrescrita da v1."""
+        produto_id, _ = repo.upsert_produto(self.conn, nome="Leite 1L", ean="7891234567895")
+        for centavos in (599, 649, 629, 579, 899, 619):
+            repo.registrar_preco(
+                self.conn, produto_id=produto_id, loja_id=self.loja_id, preco_centavos=centavos
+            )
+
+        dados = repo.preco_referencia(self.conn, produto_id)
+        self.assertEqual(dados["amostras"], 6)
+        self.assertEqual(dados["minimo"], 579)
+        self.assertEqual(dados["mediana"], 619)
+        self.assertEqual(dados["p25"], 599)
+
+    def test_sem_historico(self):
+        produto_id, _ = repo.upsert_produto(self.conn, nome="Item novo")
+        dados = repo.preco_referencia(self.conn, produto_id)
+        self.assertEqual(dados["amostras"], 0)
+        self.assertIsNone(dados["mediana"])
+
+    def test_historico_preserva_todas_as_observacoes(self):
+        """O INSERT OR REPLACE da v1 descartava o preço anterior a cada import."""
+        produto_id, _ = repo.upsert_produto(self.conn, nome="Leite 1L", ean="7891234567895")
+        for centavos in (599, 649, 579):
+            repo.registrar_preco(
+                self.conn, produto_id=produto_id, loja_id=self.loja_id, preco_centavos=centavos
+            )
+        total = self.conn.execute(
+            "SELECT COUNT(*) FROM precos_coletados WHERE produto_id = ?", (produto_id,)
+        ).fetchone()[0]
+        self.assertEqual(total, 3)
+
+
+class TestBackup(unittest.TestCase):
+    def test_backup_gera_copia_utilizavel(self):
+        with tempfile.TemporaryDirectory() as pasta:
+            origem = Path(pasta) / "origem.db"
+            destino = Path(pasta) / "backup" / "copia.db"
+
+            conn = db.conectar(origem)
+            db.migrar(conn)
+            repo.upsert_produto(conn, nome="Leite 1L", ean="7891234567895")
+            conn.commit()
+            db.backup(conn, destino)
+            conn.close()
+
+            self.assertTrue(destino.exists())
+            copia = db.conectar(destino)
+            self.assertEqual(repo.contar_produtos(copia), 1)
+            copia.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/precos/tests/test_texto.py
+++ b/precos/tests/test_texto.py
@@ -1,0 +1,85 @@
+"""Normalização de título e de EAN."""
+
+import unittest
+
+from ..normalize.texto import (
+    expandir_abreviacoes,
+    normalizar_ean,
+    normalizar_titulo,
+    remover_acentos,
+    validar_ean,
+)
+
+
+class TestNormalizarTitulo(unittest.TestCase):
+    def test_minusculas_sem_acento_sem_pontuacao(self):
+        self.assertEqual(normalizar_titulo("Café Torrado & Moído"), "cafe torrado moido")
+
+    def test_colapsa_espacos(self):
+        self.assertEqual(normalizar_titulo("  Leite   Integral  "), "leite integral")
+
+    def test_expande_abreviacoes(self):
+        self.assertEqual(normalizar_titulo("Leite Int"), "leite integral")
+        self.assertEqual(normalizar_titulo("Biscoito c/ Recheio"), "biscoito com recheio")
+
+    def test_grafias_diferentes_convergem(self):
+        self.assertEqual(
+            normalizar_titulo("Leite INT. Italac"), normalizar_titulo("leite integral italac")
+        )
+
+    def test_vazio(self):
+        self.assertEqual(normalizar_titulo(None), "")
+        self.assertEqual(normalizar_titulo(""), "")
+
+    def test_remover_acentos(self):
+        self.assertEqual(remover_acentos("Ação Ñandú"), "Acao Nandu")
+
+    def test_expandir_preserva_desconhecidas(self):
+        self.assertEqual(expandir_abreviacoes("Leite Italac"), "Leite Italac")
+
+
+class TestNormalizarEan(unittest.TestCase):
+    def test_texto_simples(self):
+        self.assertEqual(normalizar_ean("7891234567895"), "7891234567895")
+
+    def test_float_do_excel(self):
+        # O caso concreto: pandas/Excel transformam o código em número
+        self.assertEqual(normalizar_ean(7891234567895.0), "7891234567895")
+        self.assertEqual(normalizar_ean("7891234567895.0"), "7891234567895")
+
+    def test_notacao_cientifica(self):
+        self.assertEqual(normalizar_ean("7.891234567895E+12"), "7891234567895")
+
+    def test_zero_a_esquerda_perdido(self):
+        # 12 dígitos que não são UPC viram EAN-13 com zero à esquerda
+        self.assertEqual(normalizar_ean("789123456789"), "789123456789")
+        self.assertEqual(len(normalizar_ean("78912345678")), 12)
+
+    def test_com_separadores(self):
+        self.assertEqual(normalizar_ean("789-1234-567895"), "7891234567895")
+
+    def test_descarta_lixo(self):
+        for entrada in (None, "", "   ", "SEM EAN", "123", float("nan")):
+            with self.subTest(entrada=entrada):
+                self.assertIsNone(normalizar_ean(entrada))
+
+
+class TestValidarEan(unittest.TestCase):
+    def test_ean13_valido(self):
+        # dígito verificador calculado: 7891234567895
+        self.assertTrue(validar_ean("7891234567895"))
+
+    def test_ean13_invalido(self):
+        self.assertFalse(validar_ean("7891234567890"))
+
+    def test_ean8(self):
+        self.assertTrue(validar_ean("96385074"))
+
+    def test_formato_errado(self):
+        for entrada in (None, "", "abc", "123", "789123456789012345"):
+            with self.subTest(entrada=entrada):
+                self.assertFalse(validar_ean(entrada))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/precos/tests/test_vtex.py
+++ b/precos/tests/test_vtex.py
@@ -1,0 +1,254 @@
+"""Coletor VTEX (F02) — testado offline, sem tocar a rede."""
+
+import json
+import unittest
+
+from .. import config
+from ..collectors.base import ColetaAnomala, ErroDeColeta
+from ..collectors.vtex import ColetorVtex
+
+
+def produto(
+    nome="Leite Italac Integral 1L",
+    ean="7891234567895",
+    preco=5.99,
+    de=None,
+    disponivel=True,
+    product_id="1",
+):
+    return {
+        "productId": product_id,
+        "productName": nome,
+        "brand": "Italac",
+        "link": f"https://loja.exemplo/{product_id}",
+        "items": [
+            {
+                "itemId": f"sku-{product_id}",
+                "name": nome,
+                "ean": ean,
+                "sellers": [
+                    {
+                        "sellerId": "1",
+                        "commertialOffer": {
+                            "Price": preco,
+                            "ListPrice": de,
+                            "AvailableQuantity": 10 if disponivel else 0,
+                            "IsAvailable": disponivel,
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class RespostaFake:
+    def __init__(self, dados, status_code=200):
+        self._dados = dados
+        self.status_code = status_code
+        self.text = json.dumps(dados) if dados is not None else ""
+
+    def json(self):
+        if self._dados is None:
+            raise ValueError("sem JSON")
+        return self._dados
+
+
+class SessaoFake:
+    """Devolve páginas pré-definidas e registra o que foi pedido."""
+
+    def __init__(self, paginas, status=200):
+        self.paginas = list(paginas)
+        self.status = status
+        self.chamadas = []
+
+    def get(self, url, **kwargs):
+        self.chamadas.append((url, kwargs.get("params", {})))
+        dados = self.paginas.pop(0) if self.paginas else []
+        status = self.status if callable(self.status) is False else self.status
+        return RespostaFake(dados, status)
+
+
+def fonte(**kwargs):
+    padrao = dict(
+        slug="teste",
+        nome="Loja Teste",
+        base_url="https://loja.exemplo",
+        nome_loja="Loja Teste",
+        piso_esperado=1,
+    )
+    padrao.update(kwargs)
+    return config.FonteVtex(**padrao)
+
+
+class TestExtracao(unittest.TestCase):
+    def coletar(self, paginas, **kwargs):
+        sessao = SessaoFake(paginas)
+        coletor = ColetorVtex(
+            fonte(**kwargs.pop("fonte_kwargs", {})),
+            sessao=sessao,
+            pausa_s=0,
+            dormir=lambda _: None,
+            **kwargs,
+        )
+        return coletor.coletar(), sessao
+
+    def test_extrai_campos(self):
+        ofertas, _ = self.coletar([[produto()]])
+        self.assertEqual(len(ofertas), 1)
+        oferta = ofertas[0]
+        self.assertEqual(oferta.titulo_original, "Leite Italac Integral 1L")
+        self.assertEqual(oferta.preco_centavos, 599)
+        self.assertEqual(oferta.ean_informado, "7891234567895")
+        self.assertEqual(oferta.marca, "Italac")
+        self.assertTrue(oferta.disponivel)
+
+    def test_preco_de_maior_vira_preco_de(self):
+        ofertas, _ = self.coletar([[produto(preco=5.99, de=7.49)]])
+        self.assertEqual(ofertas[0].preco_de_centavos, 749)
+
+    def test_preco_de_sem_desconto_e_ignorado(self):
+        """'De R$5,99 por R$5,99' não é preço-de; virava desconto fantasma."""
+        ofertas, _ = self.coletar([[produto(preco=5.99, de=5.99)]])
+        self.assertIsNone(ofertas[0].preco_de_centavos)
+
+    def test_indisponivel_e_marcado(self):
+        ofertas, _ = self.coletar([[produto(disponivel=False)]])
+        self.assertFalse(ofertas[0].disponivel)
+
+    def test_preco_zero_e_ignorado(self):
+        with self.assertRaises(ColetaAnomala):
+            self.coletar([[produto(preco=0)]])
+
+    def test_ean_ausente_nao_impede_coleta(self):
+        ofertas, _ = self.coletar([[produto(ean=None)]])
+        self.assertIsNone(ofertas[0].ean_informado)
+        self.assertEqual(ofertas[0].preco_centavos, 599)
+
+    def test_payload_bruto_permite_reprocessar(self):
+        ofertas, _ = self.coletar([[produto()]])
+        payload = json.loads(ofertas[0].payload_bruto)
+        self.assertEqual(payload["commertialOffer"]["Price"], 5.99)
+
+    def test_skus_distintos_viram_ofertas_distintas(self):
+        p = produto()
+        p["items"].append(
+            {
+                "itemId": "sku-2",
+                "name": "Leite Italac Integral 200ml",
+                "ean": "7891234567901",
+                "sellers": [
+                    {"sellerId": "1", "commertialOffer": {"Price": 2.49, "IsAvailable": True}}
+                ],
+            }
+        )
+        ofertas, _ = self.coletar([[p]])
+        self.assertEqual(len(ofertas), 2)
+        self.assertEqual({o.preco_centavos for o in ofertas}, {599, 249})
+
+
+class TestPaginacao(unittest.TestCase):
+    def test_para_na_pagina_incompleta(self):
+        pagina_cheia = [produto(product_id=str(i), ean=None) for i in range(50)]
+        sessao = SessaoFake([pagina_cheia, [produto(product_id="x", ean=None)]])
+        coletor = ColetorVtex(
+            fonte(), sessao=sessao, pausa_s=0, dormir=lambda _: None
+        )
+        ofertas = coletor.coletar()
+        self.assertEqual(len(ofertas), 51)
+        self.assertEqual(len(sessao.chamadas), 2)
+
+    def test_janela_inclusiva(self):
+        sessao = SessaoFake([[produto()]])
+        ColetorVtex(fonte(), sessao=sessao, pausa_s=0, dormir=lambda _: None).coletar()
+        _, params = sessao.chamadas[0]
+        self.assertEqual(params["_from"], 0)
+        self.assertEqual(params["_to"], config.VTEX_TAMANHO_PAGINA - 1)
+
+    def test_limite_respeitado(self):
+        pagina = [produto(product_id=str(i), ean=None) for i in range(50)]
+        sessao = SessaoFake([pagina, pagina])
+        coletor = ColetorVtex(
+            fonte(), sessao=sessao, limite=10, pausa_s=0, dormir=lambda _: None
+        )
+        self.assertEqual(len(coletor.coletar()), 10)
+
+    def test_duplicatas_entre_paginas(self):
+        mesmo = produto(product_id="1")
+        sessao = SessaoFake([[mesmo], [mesmo]])
+        coletor = ColetorVtex(fonte(), sessao=sessao, pausa_s=0, dormir=lambda _: None)
+        self.assertEqual(len(coletor.coletar()), 1)
+
+    def test_categorias_geram_consultas_separadas(self):
+        sessao = SessaoFake([[produto(product_id="1")], [produto(product_id="2", ean=None)]])
+        coletor = ColetorVtex(
+            fonte(categorias=("10", "20")), sessao=sessao, pausa_s=0, dormir=lambda _: None
+        )
+        coletor.coletar()
+        self.assertEqual(sessao.chamadas[0][1]["fq"], "C:/10/")
+        self.assertEqual(sessao.chamadas[1][1]["fq"], "C:/20/")
+
+
+class TestHealthCheck(unittest.TestCase):
+    def test_coleta_vazia_falha_alto(self):
+        """O modo de falha mais perigoso: 0 itens parecendo 'não teve oferta hoje'."""
+        sessao = SessaoFake([[]])
+        coletor = ColetorVtex(
+            fonte(piso_esperado=20), sessao=sessao, pausa_s=0, dormir=lambda _: None
+        )
+        with self.assertRaises(ColetaAnomala) as ctx:
+            coletor.coletar()
+        self.assertIn("anômala", str(ctx.exception))
+
+    def test_coleta_abaixo_do_piso_falha(self):
+        sessao = SessaoFake([[produto()]])
+        coletor = ColetorVtex(
+            fonte(piso_esperado=100), sessao=sessao, pausa_s=0, dormir=lambda _: None
+        )
+        with self.assertRaises(ColetaAnomala):
+            coletor.coletar()
+
+
+class TestErrosHttp(unittest.TestCase):
+    def test_404_nao_repete(self):
+        sessao = SessaoFake([[]], status=404)
+        coletor = ColetorVtex(fonte(), sessao=sessao, pausa_s=0, dormir=lambda _: None)
+        with self.assertRaises(ErroDeColeta):
+            coletor.coletar()
+        self.assertEqual(len(sessao.chamadas), 1)
+
+    def test_500_repete_e_desiste(self):
+        sessao = SessaoFake([[]] * 10, status=500)
+        coletor = ColetorVtex(fonte(), sessao=sessao, pausa_s=0, dormir=lambda _: None)
+        with self.assertRaises(ErroDeColeta):
+            coletor.coletar()
+        self.assertEqual(len(sessao.chamadas), config.MAX_TENTATIVAS)
+
+    def test_206_e_sucesso(self):
+        """206 Partial Content é a resposta normal da busca paginada VTEX."""
+        sessao = SessaoFake([[produto()]], status=206)
+        coletor = ColetorVtex(fonte(), sessao=sessao, pausa_s=0, dormir=lambda _: None)
+        self.assertEqual(len(coletor.coletar()), 1)
+
+    def test_resposta_nao_json(self):
+        class SessaoQuebrada:
+            def get(self, url, **kwargs):
+                return RespostaFake(None, 200)
+
+        coletor = ColetorVtex(fonte(), sessao=SessaoQuebrada(), pausa_s=0, dormir=lambda _: None)
+        with self.assertRaises(ErroDeColeta):
+            coletor.coletar()
+
+    def test_formato_inesperado(self):
+        class SessaoDict:
+            def get(self, url, **kwargs):
+                return RespostaFake({"erro": "acesso negado"}, 200)
+
+        coletor = ColetorVtex(fonte(), sessao=SessaoDict(), pausa_s=0, dormir=lambda _: None)
+        with self.assertRaises(ErroDeColeta) as ctx:
+            coletor.coletar()
+        self.assertIn("formato inesperado", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que é

Revisão técnica do PRD v1.0 do sistema de comparação de preços (iFood × varejo), o PRD v2 corrigido, e a implementação das duas primeiras fases do roadmap.

## Documentação

| Arquivo | Conteúdo |
|---|---|
| `docs/REVIEW_PRD_PRECOS.md` | Veredito por feature, 9 defeitos de schema, análise dos 3 módulos de código, respostas aos 4 riscos da seção 6 |
| `docs/PRD_PRECOS_V2.md` | Schema completo, pipeline de matching, regras de alerta, estrutura de módulos, roadmap |

**O defeito estrutural da v1:** o banco não guardava histórico. `produtos_base` tinha uma única coluna `preco_referencia`, sobrescrita a cada `INSERT OR REPLACE`. Sem série temporal não existe preço médio, percentil nem "menor preço em 90 dias" — o sistema só conseguiria responder "está abaixo da planilha que eu digitei".

Outros achados: `ean` como PRIMARY KEY excluía hortifruti e granel; a FK em `ofertas_ifood` descartava produtos novos e nem era aplicada (checagem desligada por padrão no SQLite); `fuzz.WRatio` com corte em 85 casa "Leite 1L" com "Leite 200ml"; o F05 tinha o título "Regra de Alerta:" e nada abaixo; sem dedupe a mesma oferta alertaria a cada execução.

## Implementação (`precos/`)

**Fase 1 — schema + importador de planilha (F01)**

- `storage/` — conexão com `PRAGMA foreign_keys=ON` em toda conexão, migração idempotente, backup consistente via API online do SQLite, e repositórios concentrando todo o SQL.
- `normalize/` — `parse_preco_brl` (centavos inteiros; milhar/decimal pt-BR, NBSP, centavos em elemento separado), `parse_quantidade` (multiplicador `2x500ml`, conversão para g/ml/un) e `normalizar_ean` (conserta float e notação científica vindos do Excel) com validação de dígito GTIN.
- `collectors/planilha.py` — CSV pela biblioteca padrão, XLSX opcional. Aceita `Preco_Referencia` e `Preco`, além de cabeçalhos acentuados. Linha inválida é descartada com motivo registrado, nunca gravada como NaN.

**Fase 2 — coletor VTEX (F02)**

- `collectors/vtex.py` — catálogo público (`/api/catalog_system/pub/products/search`) com paginação por janela inclusiva, backoff exponencial, pausa entre requisições, dedupe entre páginas e health check que levanta `ColetaAnomala` quando a coleta fica abaixo do piso.
- Sessão HTTP injetável, o que mantém os testes offline.

**Decisões que divergem do PRD v1**, documentadas em `precos/README.md`: sem pandas (a inferência de tipo é justamente o que corrompe o EAN, e são ~50 MB para ler alguns milhares de linhas) e sem Playwright/BeautifulSoup na fase 2 (os seletores `vtex-product-summary-2-x-*` carregam a versão do componente no nome e quebram sem erro).

## Verificação

- **95 testes passando**, biblioteca padrão apenas, sem rede.
- DDL executado em SQLite 3.45.1; índice único parcial aceita vários produtos sem EAN, rejeita EAN duplicado, FK efetivamente aplicada.
- Fluxo ponta a ponta exercitado: `migrar` → `importar` → `coletar` → `status` → `referencia`. Reimportar a mesma planilha gera 0 produtos novos e **acumula** histórico (obs=2 por produto), confirmando que o defeito da v1 está corrigido.
- Quantidades extraídas corretamente na importação de exemplo: `2x400g` → 800g, `5kg` → 5000g, `kg` → 1000g para hortifruti sem EAN.

## Sobre a coleta do iFood

O item 1 da seção 6 do PRD pedia estratégia de contorno da proteção antibot. Isso não foi desenhado. A revisão registra a recusa e detalha os caminhos legítimos: catálogo público VTEX, dados de NFC-e via SEFAZ, captura assistida e o canal oficial de parceiro.

Ressalva registrada no documento: **não foi encontrada API pública documentada** para o programa Menor Preço Brasil — o encaminhamento sugerido é solicitar acesso institucional à SEFAZ, não fazer engenharia reversa da API do app.

## Não verificado

O host da loja e o comportamento do endpoint VTEX não foram testados contra o varejista real — o ambiente onde isso foi escrito não tem saída de rede para esses domínios. `precos/README.md` lista o que confirmar antes de rodar em rotina (requisição manual, `robots.txt`, Termos de Uso, User-Agent, volume).